### PR TITLE
Feat/notification service 48

### DIFF
--- a/notification-service/src/main/java/com/destiny/notificationservice/application/service/NotificationServiceImpl.java
+++ b/notification-service/src/main/java/com/destiny/notificationservice/application/service/NotificationServiceImpl.java
@@ -1,25 +1,53 @@
 package com.destiny.notificationservice.application.service;
 
+import com.destiny.notificationservice.domain.model.BrandNotificationChannel;
+import com.destiny.notificationservice.domain.model.BrandNotificationLog;
+import com.destiny.notificationservice.domain.repository.NotificationChannelRepository;
+import com.destiny.notificationservice.domain.repository.NotificationLogRepository;
 import com.destiny.notificationservice.presentation.dto.request.NotificationLogSearchRequest;
 import com.destiny.notificationservice.presentation.dto.request.OrderCreatedNotificationRequest;
 import com.destiny.notificationservice.presentation.dto.request.SagaErrorNotificationRequest;
+import com.destiny.notificationservice.presentation.dto.response.NotificationLogItemResponse;
 import com.destiny.notificationservice.presentation.dto.response.NotificationLogPageResponse;
 import com.destiny.notificationservice.presentation.dto.response.NotificationResultResponse;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class NotificationServiceImpl implements NotificationService {
 
+    private static final String STATUS_SUCCESS = "SUCCESS";
+    private static final String STATUS_FAIL = "FAIL";
+
+    private final NotificationChannelRepository notificationChannelRepository;
+    private final NotificationLogRepository notificationLogRepository;
+    private final RestTemplate restTemplate;
+
     @Override
     public NotificationResultResponse sendOrderCreatedNotification(
         OrderCreatedNotificationRequest request
     ) {
-        return new NotificationResultResponse("SUCCESS", "Notification request accepted");
+        String slackMessage = formatOrderMessage(request);
+
+        return sendToSlackAndLog(
+            request.brandId(),
+            slackMessage,
+            null,
+            null
+        );
 
     }
 
@@ -27,9 +55,118 @@ public class NotificationServiceImpl implements NotificationService {
     public NotificationResultResponse sendSagaErrorNotification(
         SagaErrorNotificationRequest request
     ) {
-        return new NotificationResultResponse("SUCCESS", "Saga error notification received");
+        String slackMessage = formatSagaErrorMessage(request);
+
+        return sendToSlackAndLog(
+            request.brandId(),
+            slackMessage,
+            request.errorCode(),
+            request.errorMessage()
+        );
 
     }
+
+    private NotificationResultResponse sendToSlackAndLog(
+        UUID brandId,
+        String message,
+        String errorCode,
+        String errorMessage
+    ) {
+        BrandNotificationChannel channel = notificationChannelRepository.findByBrandId(brandId).orElse(null);
+
+        if (channel == null || !channel.isActive()) {
+            saveLog(
+                brandId,
+                message,
+                STATUS_FAIL,
+                404,
+                "Channel not found or inactive",
+                "CHANNEL_NOT_AVAILABLE",
+                "No active notification channel for brand: " + brandId
+            );
+            return new NotificationResultResponse(
+                STATUS_FAIL,
+                "Slack channel not found."
+            );
+        }
+
+        try {
+            Map<String, String> payload = Collections.singletonMap("text", message);
+
+            ResponseEntity<String> response = restTemplate.postForEntity(
+                channel.getSlackUrl(),
+                payload,
+                String.class
+            );
+
+            int statusCode = response.getStatusCodeValue();
+            boolean success = response.getStatusCode().is2xxSuccessful();
+            String responseBody = response.getBody();
+
+            saveLog(
+                brandId,
+                message,
+                success ? STATUS_SUCCESS : STATUS_FAIL,
+                statusCode,
+                responseBody,
+                errorCode,
+                errorMessage
+            );
+
+            if (success) {
+                return new NotificationResultResponse(
+                    STATUS_SUCCESS,
+                    "Notification sent."
+                );
+            } else {
+                return new NotificationResultResponse(
+                    STATUS_FAIL,
+                    "Slack returned non-2xx status."
+                );
+            }
+        } catch (Exception e) {
+            log.error("Slack sending failed for BrandId={}", brandId, e);
+
+            saveLog(
+                brandId,
+                message,
+                STATUS_FAIL,
+                500,
+                "Slack request failed",
+                "SLACK_SEND_FAILED",
+                e.getMessage()
+            );
+
+            return new NotificationResultResponse(
+                STATUS_FAIL,
+                "Slack request failed."
+            );
+        }
+    }
+
+    private void saveLog(
+        UUID brandId,
+        String message,
+        String status,
+        Integer responseCode,
+        String responseMsg,
+        String errorCode,
+        String errorMessage
+    ) {
+        BrandNotificationLog logEntity = BrandNotificationLog.builder()
+            .brandId(brandId)
+            .message(message)
+            .status(status)
+            .responseCode(responseCode)
+            .responseMessage(responseMsg)
+            .errorCode(errorCode)
+            .errorMessage(errorMessage)
+            .build();
+
+        notificationLogRepository.save(logEntity);
+    }
+
+
 
     @Override
     @Transactional(readOnly = true)
@@ -37,6 +174,72 @@ public class NotificationServiceImpl implements NotificationService {
         NotificationLogSearchRequest searchRequest,
         Pageable pageable
     ) {
-        throw new UnsupportedOperationException("아직 미구현된 메서드입니다.");
+        Page<BrandNotificationLog> pageResult = notificationLogRepository.findAllBySearch(
+            searchRequest.brandId(),
+            searchRequest.status(),
+            pageable
+        );
+
+        List<NotificationLogItemResponse> content = pageResult.getContent().stream()
+            .map(log -> new NotificationLogItemResponse(
+                log.getId(),
+                log.getBrandId(),
+                log.getMessage(),
+                log.getStatus(),
+                log.getResponseCode(),
+                log.getResponseMessage(),
+                log.getErrorCode(),
+                log.getErrorMessage(),
+                log.getCreatedAt()
+            ))
+            .toList();
+
+        return new NotificationLogPageResponse(
+            content,
+            pageResult.getNumber(),
+            pageResult.getSize(),
+            pageResult.getTotalElements(),
+            pageResult.getTotalPages()
+        );
+    }
+
+
+    private String formatOrderMessage(OrderCreatedNotificationRequest req) {
+        return String.format(
+            "📢 *[신규 주문 알림]*\n" +
+                "주문번호: %s\n" +
+                "브랜드ID: %s\n" +
+                "상품: %s (%s)\n" +
+                "수량: %d개 / 금액: %d원\n" +
+                "구매자: %s (%s)\n" +
+                "메시지: %s",
+            req.orderNumber(),
+            req.brandId(),
+            req.productName(),
+            req.option(),
+            req.quantity(),
+            req.totalPrice(),
+            req.buyerName(),
+            req.buyerEmail(),
+            req.message()
+        );
+    }
+
+    private String formatSagaErrorMessage(SagaErrorNotificationRequest req) {
+        return String.format(
+            "🚨 *[주문 처리 실패]*\n" +
+                "주문ID: %s\n" +
+                "브랜드ID: %s\n" +
+                "실패 단계: %s\n" +
+                "에러코드: %s\n" +
+                "사유: %s\n" +
+                "상세 메시지: %s",
+            req.orderId(),
+            req.brandId(),
+            req.stage(),
+            req.errorCode(),
+            req.errorMessage(),
+            req.message()
+        );
     }
 }

--- a/notification-service/src/main/java/com/destiny/notificationservice/application/service/NotificationServiceImpl.java
+++ b/notification-service/src/main/java/com/destiny/notificationservice/application/service/NotificationServiceImpl.java
@@ -99,7 +99,7 @@ public class NotificationServiceImpl implements NotificationService {
                 String.class
             );
 
-            int statusCode = response.getStatusCodeValue();
+            int statusCode = response.getStatusCode().value();
             boolean success = response.getStatusCode().is2xxSuccessful();
             String responseBody = response.getBody();
 

--- a/notification-service/src/main/java/com/destiny/notificationservice/application/service/NotificationServiceImpl.java
+++ b/notification-service/src/main/java/com/destiny/notificationservice/application/service/NotificationServiceImpl.java
@@ -203,6 +203,10 @@ public class NotificationServiceImpl implements NotificationService {
         );
     }
 
+    private String nvl(Object value) {
+        return value == null ? "없음" : value.toString();
+    }
+
 
     private String formatOrderMessage(OrderCreatedNotificationRequest req) {
         return String.format(
@@ -216,12 +220,12 @@ public class NotificationServiceImpl implements NotificationService {
             req.orderNumber(),
             req.brandId(),
             req.productName(),
-            req.option(),
+            nvl(req.option()),
             req.quantity(),
             req.totalPrice(),
             req.buyerName(),
             req.buyerEmail(),
-            req.message()
+            nvl(req.message())
         );
     }
 
@@ -237,9 +241,9 @@ public class NotificationServiceImpl implements NotificationService {
             req.orderId(),
             req.brandId(),
             req.stage(),
-            req.errorCode(),
-            req.errorMessage(),
-            req.message()
+            nvl(req.errorCode()),
+            nvl(req.errorMessage()),
+            nvl(req.message())
         );
     }
 }

--- a/notification-service/src/main/java/com/destiny/notificationservice/domain/model/BrandNotificationChannel.java
+++ b/notification-service/src/main/java/com/destiny/notificationservice/domain/model/BrandNotificationChannel.java
@@ -1,0 +1,39 @@
+package com.destiny.notificationservice.domain.model;
+
+import com.destiny.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "p_brand_notification_channel")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BrandNotificationChannel extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(nullable = false)
+    private UUID brandId;
+
+    @Column(name = "slack_channel", nullable = false, length = 200)
+    private String slackUrl;
+
+    @Column(nullable = false)
+    private boolean isActive;
+
+    public BrandNotificationChannel(UUID brandId, String slackUrl) {
+        this.brandId = brandId;
+        this.slackUrl = slackUrl;
+        this.isActive = true;
+    }
+}

--- a/notification-service/src/main/java/com/destiny/notificationservice/domain/model/BrandNotificationLog.java
+++ b/notification-service/src/main/java/com/destiny/notificationservice/domain/model/BrandNotificationLog.java
@@ -1,0 +1,68 @@
+package com.destiny.notificationservice.domain.model;
+
+import com.destiny.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "p_brand_notification_log")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BrandNotificationLog extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(nullable = false)
+    private UUID brandId;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String message;
+
+    @Column(nullable = false, length = 10)
+    private String status;
+
+
+
+    private Integer responseCode;
+
+    @Column(columnDefinition = "TEXT")
+    private String responseMessage;
+
+    @Column(length = 50)
+    private String errorCode;
+
+    @Column(columnDefinition = "TEXT")
+    private String errorMessage;
+
+    @Builder
+    public BrandNotificationLog(UUID brandId, String message, String status, Integer responseCode, String responseMessage, String errorCode, String errorMessage) {
+        this.brandId = brandId;
+        this.message = message;
+        this.status = status;
+        this.responseCode = responseCode;
+        this.responseMessage = responseMessage;
+        this.errorCode = errorCode;
+        this.errorMessage = errorMessage;
+    }
+
+    public static BrandNotificationLog create(UUID brandId, String message, String status) {
+        return BrandNotificationLog.builder()
+            .brandId(brandId)
+            .message(message)
+            .status(status)
+            .build();
+    }
+
+
+}

--- a/notification-service/src/main/java/com/destiny/notificationservice/domain/repository/NotificationChannelRepository.java
+++ b/notification-service/src/main/java/com/destiny/notificationservice/domain/repository/NotificationChannelRepository.java
@@ -1,0 +1,10 @@
+package com.destiny.notificationservice.domain.repository;
+
+import com.destiny.notificationservice.domain.model.BrandNotificationChannel;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface NotificationChannelRepository {
+
+    Optional<BrandNotificationChannel> findByBrandId(UUID brandId);
+}

--- a/notification-service/src/main/java/com/destiny/notificationservice/domain/repository/NotificationLogRepository.java
+++ b/notification-service/src/main/java/com/destiny/notificationservice/domain/repository/NotificationLogRepository.java
@@ -1,0 +1,15 @@
+package com.destiny.notificationservice.domain.repository;
+
+import com.destiny.notificationservice.domain.model.BrandNotificationLog;
+import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface NotificationLogRepository {
+
+    BrandNotificationLog save(BrandNotificationLog log);
+
+    // 로그조회
+    Page<BrandNotificationLog> findAllBySearch(UUID brandId, String status, Pageable pageable);
+
+}

--- a/notification-service/src/main/java/com/destiny/notificationservice/infrastructure/client/jpa/JpaConfig.java
+++ b/notification-service/src/main/java/com/destiny/notificationservice/infrastructure/client/jpa/JpaConfig.java
@@ -1,0 +1,10 @@
+package com.destiny.notificationservice.infrastructure.client.jpa;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+
+}

--- a/notification-service/src/main/java/com/destiny/notificationservice/infrastructure/config/HttpConfig.java
+++ b/notification-service/src/main/java/com/destiny/notificationservice/infrastructure/config/HttpConfig.java
@@ -2,6 +2,7 @@ package com.destiny.notificationservice.infrastructure.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
 
 @Configuration
@@ -9,6 +10,11 @@ public class HttpConfig {
 
     @Bean
     public RestTemplate restTemplate() {
-        return new RestTemplate();
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+
+        factory.setConnectTimeout(5000);
+        factory.setReadTimeout(5000);
+
+        return new RestTemplate(factory);
     }
 }

--- a/notification-service/src/main/java/com/destiny/notificationservice/infrastructure/config/HttpConfig.java
+++ b/notification-service/src/main/java/com/destiny/notificationservice/infrastructure/config/HttpConfig.java
@@ -1,0 +1,14 @@
+package com.destiny.notificationservice.infrastructure.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class HttpConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/notification-service/src/main/java/com/destiny/notificationservice/infrastructure/repository/NotificationChannelJpaRepository.java
+++ b/notification-service/src/main/java/com/destiny/notificationservice/infrastructure/repository/NotificationChannelJpaRepository.java
@@ -1,0 +1,12 @@
+package com.destiny.notificationservice.infrastructure.repository;
+
+import com.destiny.notificationservice.domain.model.BrandNotificationChannel;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationChannelJpaRepository extends
+    JpaRepository<BrandNotificationChannel, UUID> {
+
+    Optional<BrandNotificationChannel> findByBrandId(UUID brandId);
+}

--- a/notification-service/src/main/java/com/destiny/notificationservice/infrastructure/repository/NotificationChannelRepositoryImpl.java
+++ b/notification-service/src/main/java/com/destiny/notificationservice/infrastructure/repository/NotificationChannelRepositoryImpl.java
@@ -1,0 +1,20 @@
+package com.destiny.notificationservice.infrastructure.repository;
+
+import com.destiny.notificationservice.domain.model.BrandNotificationChannel;
+import com.destiny.notificationservice.domain.repository.NotificationChannelRepository;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class NotificationChannelRepositoryImpl implements NotificationChannelRepository {
+
+    private final NotificationChannelJpaRepository jpaRepository;
+
+    @Override
+    public Optional<BrandNotificationChannel> findByBrandId(UUID brandId) {
+        return jpaRepository.findByBrandId(brandId);
+    }
+}

--- a/notification-service/src/main/java/com/destiny/notificationservice/infrastructure/repository/NotificationLogJpaRepository.java
+++ b/notification-service/src/main/java/com/destiny/notificationservice/infrastructure/repository/NotificationLogJpaRepository.java
@@ -1,0 +1,16 @@
+package com.destiny.notificationservice.infrastructure.repository;
+
+import com.destiny.notificationservice.domain.model.BrandNotificationLog;
+import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationLogJpaRepository extends JpaRepository<BrandNotificationLog, UUID> {
+
+    Page<BrandNotificationLog> findByBrandId(UUID brandId, Pageable pageable);
+
+    Page<BrandNotificationLog> findByBrandIdAndStatus(UUID brandId, String status, Pageable pageable);
+
+    Page<BrandNotificationLog> findByStatus(String status, Pageable pageable);
+}

--- a/notification-service/src/main/java/com/destiny/notificationservice/infrastructure/repository/NotificationLogRepositoryImpl.java
+++ b/notification-service/src/main/java/com/destiny/notificationservice/infrastructure/repository/NotificationLogRepositoryImpl.java
@@ -1,0 +1,34 @@
+package com.destiny.notificationservice.infrastructure.repository;
+
+import com.destiny.notificationservice.domain.model.BrandNotificationLog;
+import com.destiny.notificationservice.domain.repository.NotificationLogRepository;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class NotificationLogRepositoryImpl implements NotificationLogRepository {
+
+    private final NotificationLogJpaRepository jpaRepository;
+
+    @Override
+    public BrandNotificationLog save(BrandNotificationLog log) {
+        return jpaRepository.save(log);
+    }
+
+    @Override
+    public Page<BrandNotificationLog> findAllBySearch(UUID brandId, String status, Pageable pageable) {
+        if (brandId != null && status != null) {
+            return jpaRepository.findByBrandIdAndStatus(brandId, status, pageable);
+        } else if (brandId != null) {
+            return jpaRepository.findByBrandId(brandId, pageable);
+        } else if (status != null) {
+            return jpaRepository.findByStatus(status, pageable);
+        } else {
+            return jpaRepository.findAll(pageable);
+        }
+    }
+}


### PR DESCRIPTION
## 📝 PR 제목
> 알림 서비스 슬랙 연동 및 로그 저장

---

### 🔍 관련 이슈
- Close #48 

---

### ✨ 작업 내용 요약
> 알림 서비스에서 브랜드 슬랙 채널로 주문/Saga 에러 알림 발송

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명)

---

### ⚙️ 주요 변경 사항
> 도메인 엔티티 추가 및 도메인 전용 레포지토리 인터페이스, JPA 구현체 추가/ServiceImpl에서 공통 메서드로 주문 생성+Saga 에러 알림 발송 구현/슬랙 웹훅 호출용 RestTemplate Bean 등록

- ex) `OrderService` 내 주문 생성 로직 수정
- ex) 배송 경로 조회 API 리팩토링

---

### ✅ 테스트 및 검증 내용
> 테스트한 방법, 환경, 결과를 구체적으로 작성해주세요.

- [x] 로컬 환경 테스트 완료
- [ ] Docker 환경 실행 검증
- [x] Postman 검증 완료

---

### 📸 스크린샷 (선택)
> UI나 응답 결과 캡처가 있다면 첨부해주세요.
<img width="735" height="493" alt="image" src="https://github.com/user-attachments/assets/db46969e-c99f-4daa-9d79-9b7c9f1b060e" />
<img width="1272" height="1113" alt="image" src="https://github.com/user-attachments/assets/d7531098-e9aa-48f0-bee7-e0c334d23d73" />
<img width="1293" height="1185" alt="image" src="https://github.com/user-attachments/assets/daaa224d-8427-4b24-b409-51ce971d2f2a" />

---

### 💬 기타 참고 사항
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Slack 기반 주문 및 사가 에러 알림 전송 완전 구현
  * 브랜드별 알림 채널 등록·조회 및 활성화 상태 반영
  * 알림 전송 결과(성공/비-2xx/예외) 자동 기록 및 영속화
  * 알림 로그 조회·필터링(브랜드, 상태) 및 페이지네이션 지원
  * 알림 메시지 포맷 개선 및 전송 실패 시 상세 정보 저장
* **Chores**
  * JPA 감사 활성화 및 HTTP 클라이언트 빈 등록 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->