### PR TITLE
Feat/cart service 73

### DIFF
--- a/cart-service/build.gradle
+++ b/cart-service/build.gradle
@@ -31,7 +31,10 @@ ext {
 
 dependencies {
 
-    implementation 'com.github.team-destiny:destiny-global:0.0.1'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'com.auth0:java-jwt:4.4.0'
+
+    implementation 'com.github.team-destiny:destiny-global:0.0.2'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/cart-service/src/main/java/com/destiny/cartservice/application/service/CartService.java
+++ b/cart-service/src/main/java/com/destiny/cartservice/application/service/CartService.java
@@ -11,15 +11,15 @@ import java.util.UUID;
 
 public interface CartService {
 
-    CartFindAllResponse findAllCarts(Principal principal);
+    CartFindAllResponse findAllCarts(UUID userId);
 
-    CartSaveResponse saveCartItem(Principal principal, CartSaveRequest request);
+    CartSaveResponse saveCartItem(UUID userId, CartSaveRequest request);
 
     CartUpdateQuantityResponse updateCartItemQuantity(
-        Principal principal,
+        UUID userId,
         UUID cartId,
         CartUpdateQuantityRequest request
     );
 
-    void deleteCartItems(Principal principal, CartDeleteRequest request);
+    void deleteCartItems(UUID userId, CartDeleteRequest request);
 }

--- a/cart-service/src/main/java/com/destiny/cartservice/application/service/CartServiceImpl.java
+++ b/cart-service/src/main/java/com/destiny/cartservice/application/service/CartServiceImpl.java
@@ -11,7 +11,6 @@ import com.destiny.cartservice.presentation.dto.response.CartFindItemResponse;
 import com.destiny.cartservice.presentation.dto.response.CartSaveResponse;
 import com.destiny.cartservice.presentation.dto.response.CartUpdateQuantityResponse;
 import com.destiny.global.exception.BizException;
-import java.security.Principal;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -30,8 +29,7 @@ public class CartServiceImpl implements CartService {
     */
     @Override
     @Transactional(readOnly = true)
-    public CartFindAllResponse findAllCarts(Principal principal) {
-        UUID userId = getUserId(principal);
+    public CartFindAllResponse findAllCarts(UUID userId) {
 
         List<Cart> carts = cartRepository.findAllByUserId(userId);
 
@@ -41,11 +39,6 @@ public class CartServiceImpl implements CartService {
 
         return CartFindAllResponse.from(items);
     }
-
-    private UUID getUserId(Principal principal) {
-        return UUID.fromString(principal.getName());
-    }
-
 
     private CartFindItemResponse toItemResponse(Cart cart) {
         // TODO: 상품/옵션/가격 조회 붙이면 적용
@@ -65,8 +58,7 @@ public class CartServiceImpl implements CartService {
      * 없으면 새 장바구니 생성
      * */
     @Override
-    public CartSaveResponse saveCartItem(Principal principal, CartSaveRequest request) {
-        UUID userId = getUserId(principal);
+    public CartSaveResponse saveCartItem(UUID userId, CartSaveRequest request) {
 
         Cart cart = cartRepository.findExistingCart(userId, request.getProductId(),
                 request.getOptionId())
@@ -102,12 +94,10 @@ public class CartServiceImpl implements CartService {
     /* 장바구니 수량 변경 */
     @Override
     public CartUpdateQuantityResponse updateCartItemQuantity(
-        Principal principal,
+        UUID userId,
         UUID cartId,
         CartUpdateQuantityRequest request
     ) {
-        UUID userId = getUserId(principal);
-
         Cart cart = cartRepository.findById(cartId)
             .orElseThrow(() -> new BizException(CartErrorCode.CART_NOT_FOUND));
 
@@ -137,8 +127,7 @@ public class CartServiceImpl implements CartService {
 
     /* 장바구니 선택 삭제 */
     @Override
-    public void deleteCartItems(Principal principal, CartDeleteRequest request) {
-        UUID userId = getUserId(principal);
+    public void deleteCartItems(UUID userId, CartDeleteRequest request) {
         List<UUID> cartIds = request.getCartIds();
 
         List<Cart> ownedCarts = cartRepository.findAllByUserId(userId);

--- a/cart-service/src/main/java/com/destiny/cartservice/domain/model/Cart.java
+++ b/cart-service/src/main/java/com/destiny/cartservice/domain/model/Cart.java
@@ -1,5 +1,6 @@
 package com.destiny.cartservice.domain.model;
 
+import com.destiny.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import java.util.UUID;
 import lombok.AccessLevel;
@@ -10,7 +11,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "p_cart")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Cart {
+public class Cart extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)

--- a/cart-service/src/main/java/com/destiny/cartservice/infrastructure/client/jpa/JpaConfig.java
+++ b/cart-service/src/main/java/com/destiny/cartservice/infrastructure/client/jpa/JpaConfig.java
@@ -4,7 +4,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @Configuration
-@EnableJpaAuditing
+@EnableJpaAuditing(auditorAwareRef = "securityAuditorAware")
 public class JpaConfig {
 
 }

--- a/cart-service/src/main/java/com/destiny/cartservice/infrastructure/client/jpa/SecurityAuditorAware.java
+++ b/cart-service/src/main/java/com/destiny/cartservice/infrastructure/client/jpa/SecurityAuditorAware.java
@@ -1,0 +1,31 @@
+package com.destiny.cartservice.infrastructure.client.jpa;
+
+import com.destiny.cartservice.infrastructure.security.auth.CustomUserDetails;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@Component("securityAuditorAware")
+public class SecurityAuditorAware implements AuditorAware<UUID> {
+
+    @Override
+    public Optional<UUID> getCurrentAuditor() {
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return Optional.empty();
+        }
+
+        Object principal = authentication.getPrincipal();
+
+        if (principal instanceof CustomUserDetails userDetails) {
+            return Optional.of(userDetails.getUserId());
+        }
+
+        return Optional.empty();
+    }
+}

--- a/cart-service/src/main/java/com/destiny/cartservice/infrastructure/security/auth/CustomAccessDeniedHandler.java
+++ b/cart-service/src/main/java/com/destiny/cartservice/infrastructure/security/auth/CustomAccessDeniedHandler.java
@@ -1,0 +1,31 @@
+package com.destiny.cartservice.infrastructure.security.auth;
+
+import com.destiny.global.code.CommonErrorCode;
+import com.destiny.global.response.ApiResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response,
+        AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().print(objectMapper.writeValueAsString(
+            ApiResponse.error(CommonErrorCode.ACCESS_DENIED)
+        ));
+    }
+}

--- a/cart-service/src/main/java/com/destiny/cartservice/infrastructure/security/auth/CustomAuthenticationEntryPoint.java
+++ b/cart-service/src/main/java/com/destiny/cartservice/infrastructure/security/auth/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,31 @@
+package com.destiny.cartservice.infrastructure.security.auth;
+
+import com.destiny.global.code.CommonErrorCode;
+import com.destiny.global.response.ApiResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+        AuthenticationException authException) throws IOException, ServletException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().print(objectMapper.writeValueAsString(
+            ApiResponse.error(CommonErrorCode.UNAUTHORIZED)
+        ));
+    }
+}

--- a/cart-service/src/main/java/com/destiny/cartservice/infrastructure/security/auth/CustomUserDetails.java
+++ b/cart-service/src/main/java/com/destiny/cartservice/infrastructure/security/auth/CustomUserDetails.java
@@ -31,7 +31,13 @@ public class CustomUserDetails implements UserDetails {
         if (userIdStr == null) {
             throw new BizException(CommonErrorCode.MISSING_PARAMETER);
         }
-        customUserDetails.userId = UUID.fromString(userIdStr);
+
+        try {
+            customUserDetails.userId = UUID.fromString(userIdStr);
+        } catch (IllegalArgumentException ex) {
+            throw new BizException(CommonErrorCode.MISSING_PARAMETER);
+        }
+
         customUserDetails.username = decodedJwt.getClaim("username").asString();
         if (customUserDetails.username == null) {
             throw new BizException(CommonErrorCode.MISSING_PARAMETER);

--- a/cart-service/src/main/java/com/destiny/cartservice/infrastructure/security/auth/CustomUserDetails.java
+++ b/cart-service/src/main/java/com/destiny/cartservice/infrastructure/security/auth/CustomUserDetails.java
@@ -1,0 +1,73 @@
+package com.destiny.cartservice.infrastructure.security.auth;
+
+import com.auth0.jwt.interfaces.DecodedJWT;
+import com.destiny.global.code.CommonErrorCode;
+import com.destiny.global.exception.BizException;
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+@Getter
+public class CustomUserDetails implements UserDetails {
+
+    private UUID userId;
+    private String username;
+    private String email;
+    private String accessJwt;
+    private String userRole;
+
+    public CustomUserDetails() {};
+
+    public static CustomUserDetails of(DecodedJWT decodedJwt) {
+        CustomUserDetails customUserDetails = new CustomUserDetails();
+        String userIdStr = decodedJwt.getClaim("userId").asString();
+        if (userIdStr == null) {
+            throw new BizException(CommonErrorCode.MISSING_PARAMETER);
+        }
+        customUserDetails.userId = UUID.fromString(userIdStr);
+        customUserDetails.username = decodedJwt.getClaim("username").asString();
+        customUserDetails.email = decodedJwt.getClaim("email").asString();
+        customUserDetails.accessJwt = decodedJwt.getToken();
+        customUserDetails.userRole = decodedJwt.getClaim("userRole").asString();
+        return customUserDetails;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority("ROLE_" + userRole));
+    }
+
+    @Override
+    public String getUsername() {
+        return username;
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return UserDetails.super.isAccountNonExpired();
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return UserDetails.super.isAccountNonLocked();
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return UserDetails.super.isCredentialsNonExpired();
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return UserDetails.super.isEnabled();
+    }
+}

--- a/cart-service/src/main/java/com/destiny/cartservice/infrastructure/security/auth/CustomUserDetails.java
+++ b/cart-service/src/main/java/com/destiny/cartservice/infrastructure/security/auth/CustomUserDetails.java
@@ -20,7 +20,10 @@ public class CustomUserDetails implements UserDetails {
     private String accessJwt;
     private String userRole;
 
-    public CustomUserDetails() {};
+    public CustomUserDetails() {
+    }
+
+    ;
 
     public static CustomUserDetails of(DecodedJWT decodedJwt) {
         CustomUserDetails customUserDetails = new CustomUserDetails();
@@ -30,9 +33,18 @@ public class CustomUserDetails implements UserDetails {
         }
         customUserDetails.userId = UUID.fromString(userIdStr);
         customUserDetails.username = decodedJwt.getClaim("username").asString();
+        if (customUserDetails.username == null) {
+            throw new BizException(CommonErrorCode.MISSING_PARAMETER);
+        }
         customUserDetails.email = decodedJwt.getClaim("email").asString();
+        if (customUserDetails.email == null) {
+            throw new BizException(CommonErrorCode.MISSING_PARAMETER);
+        }
         customUserDetails.accessJwt = decodedJwt.getToken();
         customUserDetails.userRole = decodedJwt.getClaim("userRole").asString();
+        if (customUserDetails.userRole == null) {
+            throw new BizException(CommonErrorCode.MISSING_PARAMETER);
+        }
         return customUserDetails;
     }
 

--- a/cart-service/src/main/java/com/destiny/cartservice/infrastructure/security/auth/CustomUserDetails.java
+++ b/cart-service/src/main/java/com/destiny/cartservice/infrastructure/security/auth/CustomUserDetails.java
@@ -47,6 +47,10 @@ public class CustomUserDetails implements UserDetails {
             throw new BizException(CommonErrorCode.MISSING_PARAMETER);
         }
         customUserDetails.accessJwt = decodedJwt.getToken();
+        if (customUserDetails.accessJwt == null || customUserDetails.accessJwt.isBlank()) {
+            throw new BizException(CommonErrorCode.MISSING_PARAMETER);
+        }
+
         customUserDetails.userRole = decodedJwt.getClaim("userRole").asString();
         if (customUserDetails.userRole == null) {
             throw new BizException(CommonErrorCode.MISSING_PARAMETER);

--- a/cart-service/src/main/java/com/destiny/cartservice/infrastructure/security/config/SecurityConfig.java
+++ b/cart-service/src/main/java/com/destiny/cartservice/infrastructure/security/config/SecurityConfig.java
@@ -1,0 +1,55 @@
+package com.destiny.cartservice.infrastructure.security.config;
+
+
+import com.destiny.cartservice.infrastructure.security.auth.CustomAccessDeniedHandler;
+import com.destiny.cartservice.infrastructure.security.auth.CustomAuthenticationEntryPoint;
+import com.destiny.cartservice.infrastructure.security.filter.JwtAuthorizationFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity // Spring Security 지원
+// Controller, Service, Repo에서 권한/인증 감사 어노테이선 사용 허용
+// ex) @PreAuthorize("hasRole('MASTER')")
+@EnableMethodSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    // 인증 안 된 사용자가 api 접근했을 때(401) 응답 처리
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+    // 인증된 사용자가 권한이 부족할 때(403) 응답 처리
+    private final CustomAccessDeniedHandler customAccessDeniedHandler;
+    private final JwtAuthorizationFilter jwtAuthorizationFilter;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
+        httpSecurity.csrf(csrf -> csrf.disable());
+        httpSecurity.formLogin(form -> form.disable());
+        httpSecurity.httpBasic(basic -> basic.disable());
+        httpSecurity.logout(logout -> logout.disable());
+        httpSecurity.sessionManagement(session ->
+            session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
+        // 예외 처리 커스터마이징
+        httpSecurity.exceptionHandling(handler -> handler
+            .authenticationEntryPoint(customAuthenticationEntryPoint)
+            .accessDeniedHandler(customAccessDeniedHandler));
+
+        // JWT 필터 등록 (SecurityContext에 Authentication 세팅)
+        httpSecurity.addFilterBefore(jwtAuthorizationFilter, UsernamePasswordAuthenticationFilter.class);
+
+        httpSecurity.authorizeHttpRequests(authorize -> {
+            authorize.requestMatchers("/v1/carts/**").authenticated();
+            authorize.anyRequest().authenticated();
+        });
+
+        return httpSecurity.build();
+    }
+}

--- a/cart-service/src/main/java/com/destiny/cartservice/infrastructure/security/filter/JwtAuthorizationFilter.java
+++ b/cart-service/src/main/java/com/destiny/cartservice/infrastructure/security/filter/JwtAuthorizationFilter.java
@@ -1,0 +1,53 @@
+package com.destiny.cartservice.infrastructure.security.filter;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import com.destiny.cartservice.infrastructure.security.auth.CustomUserDetails;
+import com.destiny.cartservice.infrastructure.security.jwt.JwtProperties;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j(topic = "토큰 권한 인가")
+public class JwtAuthorizationFilter extends OncePerRequestFilter {
+
+    private final JwtProperties jwtProperties;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+        throws ServletException, IOException {
+
+        String authorizationHeader = request.getHeader(jwtProperties.getAccessHeaderName());
+        if (!StringUtils.hasText(authorizationHeader) || !authorizationHeader.startsWith(jwtProperties.getHeaderPrefix())) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String accessJwt = authorizationHeader.substring(jwtProperties.getHeaderPrefix().length()).trim();
+        DecodedJWT decodedAccessJwt = JWT.decode(accessJwt);
+
+        CustomUserDetails userDetails;
+        try {
+            userDetails = CustomUserDetails.of(decodedAccessJwt);
+        } catch (RuntimeException exception) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        UsernamePasswordAuthenticationToken authenticationToken =
+            new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+        filterChain.doFilter(request, response);
+    }
+}

--- a/cart-service/src/main/java/com/destiny/cartservice/infrastructure/security/jwt/JwtProperties.java
+++ b/cart-service/src/main/java/com/destiny/cartservice/infrastructure/security/jwt/JwtProperties.java
@@ -1,0 +1,25 @@
+package com.destiny.cartservice.infrastructure.security.jwt;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Component
+public class JwtProperties {
+
+    private final String secretKey;
+    private final String accessHeaderName;
+    private final String headerPrefix;
+
+    public JwtProperties(
+        @Value("${jwt.secretKey}") String secretKey,
+        @Value("${jwt.access-header-name}") String accessHeaderName,
+        @Value("${jwt.header-prefix}") String headerPrefix
+    ) {
+        this.secretKey = secretKey;
+        this.accessHeaderName = accessHeaderName;
+        this.headerPrefix = headerPrefix;
+
+    }
+}

--- a/cart-service/src/main/java/com/destiny/cartservice/presentation/controller/CartController.java
+++ b/cart-service/src/main/java/com/destiny/cartservice/presentation/controller/CartController.java
@@ -1,6 +1,7 @@
 package com.destiny.cartservice.presentation.controller;
 
 import com.destiny.cartservice.application.service.CartService;
+import com.destiny.cartservice.infrastructure.security.auth.CustomUserDetails;
 import com.destiny.cartservice.presentation.dto.request.CartDeleteRequest;
 import com.destiny.cartservice.presentation.dto.request.CartSaveRequest;
 import com.destiny.cartservice.presentation.dto.request.CartUpdateQuantityRequest;
@@ -8,11 +9,11 @@ import com.destiny.cartservice.presentation.dto.response.CartFindAllResponse;
 import com.destiny.cartservice.presentation.dto.response.CartSaveResponse;
 import com.destiny.cartservice.presentation.dto.response.CartUpdateQuantityResponse;
 import jakarta.validation.Valid;
-import java.security.Principal;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -31,35 +32,36 @@ public class CartController {
 
     // 장바구니 전체 조회
     @GetMapping
-    public ResponseEntity<CartFindAllResponse> cartFindAll(Principal principal) {
-        CartFindAllResponse response = cartService.findAllCarts(principal);
+    public ResponseEntity<CartFindAllResponse> cartFindAll(
+        @AuthenticationPrincipal CustomUserDetails user) {
+        CartFindAllResponse response = cartService.findAllCarts(user.getUserId());
         return ResponseEntity.ok(response);
 
     }
 
     // 장바구니 담기
     @PostMapping
-    public ResponseEntity<CartSaveResponse> saveCart(Principal principal,
+    public ResponseEntity<CartSaveResponse> saveCart(@AuthenticationPrincipal CustomUserDetails user,
         @RequestBody @Valid CartSaveRequest request) {
-        CartSaveResponse response = cartService.saveCartItem(principal, request);
+        CartSaveResponse response = cartService.saveCartItem(user.getUserId(), request);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
     // 장바구니 수량 변경
     @PatchMapping("/{cartId}/quantity")
     public ResponseEntity<CartUpdateQuantityResponse> updateCartItemQuantity(
-        Principal principal, @PathVariable UUID cartId,
+        @AuthenticationPrincipal CustomUserDetails user, @PathVariable UUID cartId,
         @RequestBody @Valid CartUpdateQuantityRequest request) {
-        CartUpdateQuantityResponse response = cartService.updateCartItemQuantity(principal,
+        CartUpdateQuantityResponse response = cartService.updateCartItemQuantity(user.getUserId(),
             cartId, request);
         return ResponseEntity.ok(response);
     }
 
     // 장바구니 선택 삭제
     @DeleteMapping
-    public ResponseEntity<Void> deleteCartItems(Principal principal,
+    public ResponseEntity<Void> deleteCartItems( @AuthenticationPrincipal CustomUserDetails user,
         @RequestBody CartDeleteRequest request) {
-        cartService.deleteCartItems(principal, request);
+        cartService.deleteCartItems(user.getUserId(), request);
         return ResponseEntity.noContent().build();
     }
 }

--- a/cart-service/src/main/resources/application.yml
+++ b/cart-service/src/main/resources/application.yml
@@ -29,3 +29,14 @@ eureka:
     fetch-registry: true
     service-url:
       defaultZone: http://localhost:8761/eureka/
+
+jwt:
+  secretKey: XVFkQby3tnqMa8MUDANspAtarbl1VZyT
+  access-expiration-millis: 1800000 # 30분
+  refresh-expiration-millis: 1209600000 # 14일
+  access-header-name: Authorization
+  refresh-cookie-name: X-Refresh-Token
+  header-prefix: Bearer
+  access-subject: AccessToken
+  refresh-subject: RefreshToken
+  is-refresh-cookie-secure: false


### PR DESCRIPTION
## 📝 PR 제목
> 장바구니에 JWT 인증 적용 및 사용자 식별 로직 추가

---

### 🔍 관련 이슈
- Close #73 

---

### ✨ 작업 내용 요약
>JWT 기반 인증인가 로직 추가/장바구니 CRUD를 로그인 사용자 기준으로 동작하도록 수정 

- [x] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명)

---

### ⚙️ 주요 변경 사항
> 주요 코드 변경이나 구조 변동이 있다면 작성해주세요.

- CartController: Principal제거/@AuthenticationPrincipal CustomUserDetails 인증 사용자 주입
- CartServiceImpl: Principal -> UUID userId로 변경/로그인한 사용자 기준으로 장바구니 조회검증하도록 수정
- Security: Authorization Filter 및 SecurityConfig 적용

---

### ✅ 테스트 및 검증 내용
> 테스트한 방법, 환경, 결과를 구체적으로 작성해주세요.

- [x] 로컬 환경 테스트 완료
- [ ] Docker 환경 실행 검증
- [x] Postman

---

### 📸 스크린샷 (선택)
> UI나 응답 결과 캡처가 있다면 첨부해주세요.

---

### 💬 기타 참고 사항
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * JWT 기반 인증·인가 완전 도입 — 요청 헤더 토큰으로 사용자 인증 및 권한 적용.
  * 인증 정보를 이용한 JPA 감사자 자동 기록 및 표준화된 인증 응답(401/403) 처리 제공.

* **개선 사항**
  * 장바구니 API가 명시적 사용자 식별자 기반으로 동작해 권한 검사 일관성 향상.
  * JWT 설정 항목(시크릿, 헤더명, 접두사 등)이 구성 파일에 추가됨.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->