### PR TITLE
재고 차감 로직 개선

### DIFF
--- a/stock-service/src/main/java/com/destiny/stockservice/application/dto/StockCreateMessage.java
+++ b/stock-service/src/main/java/com/destiny/stockservice/application/dto/StockCreateMessage.java
@@ -9,11 +9,7 @@ public record StockCreateMessage(
 ) {
     public Stock toEntity() {
 
-        Integer stockQuantity = 0;
-
-        if (this.quantity != null) {
-            stockQuantity = this.quantity;
-        }
+        Integer stockQuantity = (this.quantity != null) ? this.quantity : 0;
 
         return new Stock(
             this.productId,

--- a/stock-service/src/main/java/com/destiny/stockservice/domain/repository/StockRepository.java
+++ b/stock-service/src/main/java/com/destiny/stockservice/domain/repository/StockRepository.java
@@ -1,11 +1,12 @@
 package com.destiny.stockservice.domain.repository;
 
 import com.destiny.stockservice.domain.entity.Stock;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 public interface StockRepository {
     Optional<Stock> findByProductId(UUID productId);
-
     Stock save(Stock entity);
+    List<Stock> findByProductIdIn(List<UUID> productIds);
 }

--- a/stock-service/src/main/java/com/destiny/stockservice/infrastructure/repository/StockJpaRepository.java
+++ b/stock-service/src/main/java/com/destiny/stockservice/infrastructure/repository/StockJpaRepository.java
@@ -1,10 +1,12 @@
 package com.destiny.stockservice.infrastructure.repository;
 
 import com.destiny.stockservice.domain.entity.Stock;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface StockJpaRepository extends JpaRepository<Stock, UUID> {
     Optional<Stock> findByProductId(UUID productId);
+    List<Stock> findByProductIdIn(List<UUID> productIds);
 }

--- a/stock-service/src/main/java/com/destiny/stockservice/infrastructure/repository/StockRepositoryImpl.java
+++ b/stock-service/src/main/java/com/destiny/stockservice/infrastructure/repository/StockRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.destiny.stockservice.infrastructure.repository;
 
 import com.destiny.stockservice.domain.entity.Stock;
 import com.destiny.stockservice.domain.repository.StockRepository;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -21,5 +22,10 @@ public class StockRepositoryImpl implements StockRepository {
     @Override
     public Stock save(Stock stock) {
         return stockJpaRepository.save(stock);
+    }
+
+    @Override
+    public List<Stock> findByProductIdIn(List<UUID> productIds) {
+        return stockJpaRepository.findByProductIdIn(productIds);
     }
 }


### PR DESCRIPTION
## 📝 재고 차감 로직 개선

재고 차감 실패시 예외 대신 차감 실패 메세지 반환하도록 변경

재고 정보를 가져올 때 DB 반복 호출 제거, 일괄 조회 방식으로 변경

---

### 🔍 관련 이슈
- Close #이슈번호

---

### ✨ 작업 내용 요약
> 어떤 변경이 이루어졌는지 간단히 설명해주세요.

- [ ] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명)

---

### ⚙️ 주요 변경 사항
> 주요 코드 변경이나 구조 변동이 있다면 작성해주세요.

- ex) `OrderService` 내 주문 생성 로직 수정
- ex) 배송 경로 조회 API 리팩토링

---

### ✅ 테스트 및 검증 내용
> 테스트한 방법, 환경, 결과를 구체적으로 작성해주세요.

- [x] 로컬 환경 테스트 완료
- [ ] Docker 환경 실행 검증
- [ ] Postman / Swagger 검증 완료

---

### 📸 스크린샷 (선택)
> UI나 응답 결과 캡처가 있다면 첨부해주세요.

---

### 💬 기타 참고 사항
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

재고 서비스 성능 최적화가 적용되었습니다.

* **Refactor**
  * 재고 조회 성능 개선: 개별 데이터베이스 쿼리를 배치 처리 방식으로 변경하여 데이터베이스 호출 횟수 감소
  * 검증 로직 최적화: 메모리 기반 맵 활용으로 재고 검증 및 감소 처리의 효율성 향상
  * 재고 감소 프로세스 간소화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->