### PR TITLE
Feat/notification service 147

### DIFF
--- a/notification-service/build.gradle
+++ b/notification-service/build.gradle
@@ -31,10 +31,12 @@ ext {
 
 dependencies {
 
+    implementation 'org.springframework.kafka:spring-kafka'
+
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'com.auth0:java-jwt:4.4.0'
 
-    implementation 'com.github.team-destiny:destiny-global:0.0.2'
+    implementation 'com.github.team-destiny:destiny-global:0.0.3'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/notification-service/src/main/java/com/destiny/notificationservice/application/dto/event/OrderCreateSuccessEvent.java
+++ b/notification-service/src/main/java/com/destiny/notificationservice/application/dto/event/OrderCreateSuccessEvent.java
@@ -1,0 +1,18 @@
+package com.destiny.notificationservice.application.dto.event;
+
+import java.util.List;
+import java.util.UUID;
+
+public record OrderCreateSuccessEvent(
+    UUID orderId,
+    UUID userId,
+    List<OrderItem> items
+) {
+
+    public record OrderItem(
+        UUID productId,
+        UUID brandId,
+        Integer stock,
+        Integer finalAmount
+    ) {}
+}

--- a/notification-service/src/main/java/com/destiny/notificationservice/application/dto/event/SagaCreateFailedEvent.java
+++ b/notification-service/src/main/java/com/destiny/notificationservice/application/dto/event/SagaCreateFailedEvent.java
@@ -1,0 +1,12 @@
+package com.destiny.notificationservice.application.dto.event;
+
+import java.util.UUID;
+
+public record SagaCreateFailedEvent(
+    UUID orderId,
+    String failStep,
+    String errorCode,
+    String failReason,
+    String detailMessage,
+    String failService
+) {}

--- a/notification-service/src/main/java/com/destiny/notificationservice/application/service/NotificationService.java
+++ b/notification-service/src/main/java/com/destiny/notificationservice/application/service/NotificationService.java
@@ -1,5 +1,7 @@
 package com.destiny.notificationservice.application.service;
 
+import com.destiny.notificationservice.application.dto.event.SagaCreateFailedEvent;
+import com.destiny.notificationservice.application.dto.event.OrderCreateSuccessEvent;
 import com.destiny.notificationservice.presentation.dto.request.NotificationLogSearchRequest;
 import com.destiny.notificationservice.presentation.dto.request.OrderCreatedNotificationRequest;
 import com.destiny.notificationservice.presentation.dto.request.SagaErrorNotificationRequest;
@@ -16,6 +18,11 @@ public interface NotificationService {
         SagaErrorNotificationRequest request);
 
     NotificationLogPageResponse getNotificationLogs(
-
         NotificationLogSearchRequest request, Pageable pageable);
+
+
+    void sendSagaCreateFailedNotification(SagaCreateFailedEvent event);
+
+    void sendOrderCreateSuccessNotification(OrderCreateSuccessEvent event);
+
 }

--- a/notification-service/src/main/java/com/destiny/notificationservice/domain/model/BrandNotificationLog.java
+++ b/notification-service/src/main/java/com/destiny/notificationservice/domain/model/BrandNotificationLog.java
@@ -23,7 +23,7 @@ public class BrandNotificationLog extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
 
-    @Column(nullable = false)
+    @Column(nullable = true)
     private UUID brandId;
 
     @Column(nullable = false, columnDefinition = "TEXT")

--- a/notification-service/src/main/java/com/destiny/notificationservice/infrastructure/messaging/config/KafkaConsumerConfig.java
+++ b/notification-service/src/main/java/com/destiny/notificationservice/infrastructure/messaging/config/KafkaConsumerConfig.java
@@ -33,8 +33,6 @@ public class KafkaConsumerConfig {
         properties.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
         properties.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 10);
 
-        properties.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
-
         return new DefaultKafkaConsumerFactory<>(properties);
     }
 

--- a/notification-service/src/main/java/com/destiny/notificationservice/infrastructure/messaging/config/KafkaConsumerConfig.java
+++ b/notification-service/src/main/java/com/destiny/notificationservice/infrastructure/messaging/config/KafkaConsumerConfig.java
@@ -1,0 +1,41 @@
+package com.destiny.notificationservice.infrastructure.messaging.config;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+
+@EnableKafka
+@Configuration
+public class KafkaConsumerConfig {
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    @Value("${spring.kafka.consumer.group-id}")
+    private String groupId;
+
+    @Bean
+    public ConsumerFactory<String, String> consumerFactory() {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        properties.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+        properties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        properties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        return new DefaultKafkaConsumerFactory<>(properties);
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, String> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory());
+        return factory;
+    }
+}

--- a/notification-service/src/main/java/com/destiny/notificationservice/infrastructure/messaging/config/KafkaConsumerConfig.java
+++ b/notification-service/src/main/java/com/destiny/notificationservice/infrastructure/messaging/config/KafkaConsumerConfig.java
@@ -29,13 +29,22 @@ public class KafkaConsumerConfig {
         properties.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
         properties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         properties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+
+        properties.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        properties.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 10);
+
+        properties.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
+
         return new DefaultKafkaConsumerFactory<>(properties);
     }
 
     @Bean
     public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory() {
-        ConcurrentKafkaListenerContainerFactory<String, String> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        ConcurrentKafkaListenerContainerFactory<String, String> factory =
+            new ConcurrentKafkaListenerContainerFactory<>();
+
         factory.setConsumerFactory(consumerFactory());
+
         return factory;
     }
 }

--- a/notification-service/src/main/java/com/destiny/notificationservice/infrastructure/messaging/config/KafkaProducerConfig.java
+++ b/notification-service/src/main/java/com/destiny/notificationservice/infrastructure/messaging/config/KafkaProducerConfig.java
@@ -1,0 +1,35 @@
+package com.destiny.notificationservice.infrastructure.messaging.config;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+
+@EnableKafka
+@Configuration
+public class KafkaProducerConfig {
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    @Bean
+    public ProducerFactory<String, String> producerFactory() {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        properties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        properties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        return new DefaultKafkaProducerFactory<>(properties);
+    }
+
+    @Bean
+    public KafkaTemplate<String, String> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+}

--- a/notification-service/src/main/java/com/destiny/notificationservice/infrastructure/messaging/consumer/NotificationConsumer.java
+++ b/notification-service/src/main/java/com/destiny/notificationservice/infrastructure/messaging/consumer/NotificationConsumer.java
@@ -1,9 +1,8 @@
 package com.destiny.notificationservice.infrastructure.messaging.consumer;
 
-import com.destiny.notificationservice.application.dto.event.SagaCreateFailedEvent;
 import com.destiny.notificationservice.application.dto.event.OrderCreateSuccessEvent;
+import com.destiny.notificationservice.application.dto.event.SagaCreateFailedEvent;
 import com.destiny.notificationservice.application.service.NotificationService;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,30 +17,34 @@ public class NotificationConsumer {
     private final NotificationService notificationService;
     private final ObjectMapper objectMapper;
 
-    @KafkaListener(topics = "fail-send-message")
+    @KafkaListener(topics = "${kafka.topics.saga-failure}")
     public void handleSagaCreateFail(String message) {
+
         try {
             SagaCreateFailedEvent event = objectMapper.readValue(message,
                 SagaCreateFailedEvent.class);
-
             log.info("[Kafka] 사가 실패 이벤트 수신: {}", event);
             notificationService.sendSagaCreateFailedNotification(event);
-        } catch (JsonProcessingException e) {
+
+        } catch (Exception e) {
             log.error("[Kafka] 사가 실패 이벤트 수신 중 에러", e);
         }
     }
 
-    @KafkaListener(topics = "success-send-message")
+
+    @KafkaListener(topics = "${kafka.topics.order-success}")
     public void handleOrderCreateSuccess(String message) {
+
         try {
             OrderCreateSuccessEvent event = objectMapper.readValue(message,
                 OrderCreateSuccessEvent.class);
-
             log.info("[Kafka] 주문 성공 이벤트 수신: {}", event);
             notificationService.sendOrderCreateSuccessNotification(event);
-        } catch (JsonProcessingException e) {
+
+        } catch (Exception e) {
             log.error("[Kafka] 주문 성공 이벤트 수신 중 에러", e);
         }
+
     }
 
 }

--- a/notification-service/src/main/java/com/destiny/notificationservice/infrastructure/messaging/consumer/NotificationConsumer.java
+++ b/notification-service/src/main/java/com/destiny/notificationservice/infrastructure/messaging/consumer/NotificationConsumer.java
@@ -1,0 +1,47 @@
+package com.destiny.notificationservice.infrastructure.messaging.consumer;
+
+import com.destiny.notificationservice.application.dto.event.SagaCreateFailedEvent;
+import com.destiny.notificationservice.application.dto.event.OrderCreateSuccessEvent;
+import com.destiny.notificationservice.application.service.NotificationService;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotificationConsumer {
+
+    private final NotificationService notificationService;
+    private final ObjectMapper objectMapper;
+
+    @KafkaListener(topics = "fail-send-message")
+    public void handleSagaCreateFail(String message) {
+        try {
+            SagaCreateFailedEvent event = objectMapper.readValue(message,
+                SagaCreateFailedEvent.class);
+
+            log.info("[Kafka] 사가 실패 이벤트 수신: {}", event);
+            notificationService.sendSagaCreateFailedNotification(event);
+        } catch (JsonProcessingException e) {
+            log.error("[Kafka] 사가 실패 이벤트 수신 중 에러", e);
+        }
+    }
+
+    @KafkaListener(topics = "success-send-message")
+    public void handleOrderCreateSuccess(String message) {
+        try {
+            OrderCreateSuccessEvent event = objectMapper.readValue(message,
+                OrderCreateSuccessEvent.class);
+
+            log.info("[Kafka] 주문 성공 이벤트 수신: {}", event);
+            notificationService.sendOrderCreateSuccessNotification(event);
+        } catch (JsonProcessingException e) {
+            log.error("[Kafka] 주문 성공 이벤트 수신 중 에러", e);
+        }
+    }
+
+}

--- a/notification-service/src/main/resources/application.yml
+++ b/notification-service/src/main/resources/application.yml
@@ -5,14 +5,20 @@ slack:
   webhook:
     admin-url: ${SLACK_WEBHOOK_URL}
 
+kafka:
+  topics:
+    saga-failure: fail-send-message
+    order-success: success-send-message
+
 spring:
   application:
     name: notification-service
 
   kafka:
-    bootstrap-servers: localhost:9092
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
     consumer:
-      group-id: notification-service
+      group-id: ${KAFKA_CONSUMER_GROUP_ID:notification-service}
+
 
   datasource:
     driver-class-name: org.postgresql.Driver

--- a/notification-service/src/main/resources/application.yml
+++ b/notification-service/src/main/resources/application.yml
@@ -1,9 +1,18 @@
 server:
   port: 18140
 
+slack:
+  webhook:
+    admin-url: ${SLACK_WEBHOOK_URL}
+
 spring:
   application:
     name: notification-service
+
+  kafka:
+    bootstrap-servers: localhost:9092
+    consumer:
+      group-id: notification-service
 
   datasource:
     driver-class-name: org.postgresql.Driver


### PR DESCRIPTION
## 📝 PR 제목
> 알림 서비스 Kafka 연동 및 Saga실패/주문생성 알림 기능 구현

---

### 🔍 관련 이슈
- Close #147 

---

### ✨ 작업 내용 요약
> 주문 성공 및 사가 실패 이벤트를 수신해 슬랙으로 알림을 전송

- [x] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명)

---

### ⚙️ 주요 변경 사항
> 주요 코드 변경이나 구조 변동이 있다면 작성해주세요.

- Kafka Consumer 구현 사가 실패, 주문 성공 토픽 구독하는 리스너 구현
- 슬랙 웹훅 연동(application.yml에서 분리해 환경변수로 주입)
- BrandNotificationLog 엔티티 nullable = true로 변경

---

### ✅ 테스트 및 검증 내용
> 테스트한 방법, 환경, 결과를 구체적으로 작성해주세요.

- [x] 로컬 환경 테스트 완료
- [ ] Docker 환경 실행 검증
- [x] Postman

---

### 📸 스크린샷 (선택)
> UI나 응답 결과 캡처가 있다면 첨부해주세요.

---

### 💬 기타 참고 사항
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

**새로운 기능**
* Kafka 기반 실시간 알림 수신 및 처리 도입(주문 성공·사가 실패 이벤트)
* 주문 성공 및 실패에 대한 알림 전송 기능 추가
* Slack 관리자 알림(웹후크) 통합 및 브랜드별 주문 집계 알림 제공
* 운영 환경 설정에 Kafka 토픽 및 Slack 웹후크 설정 항목 추가

**버그 수정**
* 브랜드 알림 로그의 브랜드 식별자 null 허용으로 데이터 무결성/유연성 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->