### PR TITLE
Feat/cart service 157

### DIFF
--- a/cart-service/build.gradle
+++ b/cart-service/build.gradle
@@ -31,13 +31,15 @@ ext {
 
 dependencies {
 
+    implementation 'org.springframework.cloud:spring-cloud-starter-config'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
     implementation 'org.springframework.kafka:spring-kafka'
 
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'com.auth0:java-jwt:4.4.0'
 
     implementation 'com.github.team-destiny:destiny-global:0.0.3'
-    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/cart-service/src/main/java/com/destiny/cartservice/infrastructure/messaging/config/KafkaConsumerConfig.java
+++ b/cart-service/src/main/java/com/destiny/cartservice/infrastructure/messaging/config/KafkaConsumerConfig.java
@@ -30,6 +30,10 @@ public class KafkaConsumerConfig {
         properties.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
         properties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         properties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+
+        properties.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        properties.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 10);
+
         return new DefaultKafkaConsumerFactory<>(properties);
     }
 

--- a/cart-service/src/main/java/com/destiny/cartservice/infrastructure/messaging/consumer/OrderCartConsumer.java
+++ b/cart-service/src/main/java/com/destiny/cartservice/infrastructure/messaging/consumer/OrderCartConsumer.java
@@ -17,7 +17,7 @@ public class OrderCartConsumer {
     private final CartService cartService;
     private final ObjectMapper objectMapper;
 
-    @KafkaListener(topics = "cart-clear-request", groupId = "saga-orchestrator")
+    @KafkaListener(topics = "${kafka.topics.cart-clear-request}")
     public void handleCartClearEvent(String message) {
 
         try{

--- a/cart-service/src/main/java/com/destiny/cartservice/infrastructure/security/config/SecurityConfig.java
+++ b/cart-service/src/main/java/com/destiny/cartservice/infrastructure/security/config/SecurityConfig.java
@@ -46,6 +46,7 @@ public class SecurityConfig {
         httpSecurity.addFilterBefore(jwtAuthorizationFilter, UsernamePasswordAuthenticationFilter.class);
 
         httpSecurity.authorizeHttpRequests(authorize -> {
+            authorize.requestMatchers("/actuator/**").permitAll();
             authorize.requestMatchers("/v1/carts/**").authenticated();
             authorize.anyRequest().authenticated();
         });

--- a/cart-service/src/main/java/com/destiny/cartservice/infrastructure/security/config/SecurityConfig.java
+++ b/cart-service/src/main/java/com/destiny/cartservice/infrastructure/security/config/SecurityConfig.java
@@ -46,7 +46,10 @@ public class SecurityConfig {
         httpSecurity.addFilterBefore(jwtAuthorizationFilter, UsernamePasswordAuthenticationFilter.class);
 
         httpSecurity.authorizeHttpRequests(authorize -> {
-            authorize.requestMatchers("/actuator/**").permitAll();
+            // 최소 공개(필요 시 liveness/readiness만 추가)
+            authorize.requestMatchers("/actuator/health", "/actuator/health/**", "/actuator/info").permitAll();
+            // 메트릭/기타 엔드포인트는 인증 필요
+            authorize.requestMatchers("/actuator/**").authenticated();
             authorize.requestMatchers("/v1/carts/**").authenticated();
             authorize.anyRequest().authenticated();
         });

--- a/cart-service/src/main/resources/application.yml
+++ b/cart-service/src/main/resources/application.yml
@@ -1,44 +1,17 @@
-server:
-  port: 18170
-
 spring:
   application:
     name: cart-service
+  profiles:
+    active: dev
+  config:
+    import: "configserver:"
+  cloud:
+    config:
+      discovery:
+        enabled: true
+        service-id: config-server
 
-  kafka:
-    bootstrap-servers: localhost:9092
-    consumer:
-      group-id: saga-orchestrator
-
-  datasource:
-    driver-class-name: org.postgresql.Driver
-    url: jdbc:postgresql://localhost:5441/cart_db
-    username: root
-    password: 1234
-
-  jpa:
-    hibernate:
-      ddl-auto: update
-    show-sql: true
-    properties:
-      hibernate:
-        format_sql: true
-    database-platform: org.hibernate.dialect.PostgreSQLDialect
-
-eureka:
-  client:
-    register-with-eureka: true
-    fetch-registry: true
-    service-url:
-      defaultZone: http://localhost:8761/eureka/
-
-jwt:
-  secretKey: XVFkQby3tnqMa8MUDANspAtarbl1VZyT
-  access-expiration-millis: 1800000 # 30분
-  refresh-expiration-millis: 1209600000 # 14일
-  access-header-name: Authorization
-  refresh-cookie-name: X-Refresh-Token
-  header-prefix: Bearer
-  access-subject: AccessToken
-  refresh-subject: RefreshToken
-  is-refresh-cookie-secure: false
+  eureka:
+    client:
+      service-url:
+        defaultZone: http://localhost:8761/eureka/

--- a/cart-service/src/main/resources/application.yml
+++ b/cart-service/src/main/resources/application.yml
@@ -11,7 +11,7 @@ spring:
         enabled: true
         service-id: config-server
 
-  eureka:
-    client:
-      service-url:
-        defaultZone: http://localhost:8761/eureka/
+eureka:
+  client:
+    service-url:
+      defaultZone: http://localhost:8761/eureka/

--- a/config-server/src/main/resources/config-repo/cart-service-dev.yml
+++ b/config-server/src/main/resources/config-repo/cart-service-dev.yml
@@ -1,0 +1,54 @@
+server:
+  port: 18170
+
+kafka:
+  topics:
+    cart-clear-request: cart-clear-request
+
+spring:
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+    consumer:
+      group-id: ${KAFKA_CONSUMER_GROUP_ID:cart-service}
+
+  datasource:
+    driver-class-name: org.postgresql.Driver
+    url: jdbc:postgresql://localhost:5441/cart_db
+    username: root
+    password: 1234
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+    database-platform: org.hibernate.dialect.PostgreSQLDialect
+
+eureka:
+  client:
+    register-with-eureka: true
+    fetch-registry: true
+    service-url:
+      defaultZone: http://localhost:8761/eureka/
+
+jwt:
+  secretKey: ${JWT_SECRET_KEY:XVFkQby3tnqMa8MUDANspAtarbl1VZyT}
+  access-expiration-millis: 1800000
+  refresh-expiration-millis: 1209600000
+  access-header-name: Authorization
+  refresh-cookie-name: X-Refresh-Token
+  header-prefix: Bearer
+  access-subject: AccessToken
+  refresh-subject: RefreshToken
+  is-refresh-cookie-secure: false
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, info, prometheus
+  endpoint:
+    health:
+      show-details: when_authorized

--- a/config-server/src/main/resources/config-repo/cart-service-dev.yml
+++ b/config-server/src/main/resources/config-repo/cart-service-dev.yml
@@ -43,12 +43,3 @@ jwt:
   access-subject: AccessToken
   refresh-subject: RefreshToken
   is-refresh-cookie-secure: false
-
-management:
-  endpoints:
-    web:
-      exposure:
-        include: health, info, prometheus
-  endpoint:
-    health:
-      show-details: when_authorized


### PR DESCRIPTION
## 📝 PR 제목
> 장바구니 ConfigServer 적용 및 Kafka 컨슈머 설정 분리

---

### 🔍 관련 이슈
- Close #157 

---

### ✨ 작업 내용 요약
> ConfigServer 적용/Kafka 컨슈머에서 하드코딩 제거하고 yml기반으로 분리

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명)

---

### ⚙️ 주요 변경 사항
> 주요 코드 변경이나 구조 변동이 있다면 작성해주세요.

- Config Server 적용
- KafkaConsumerConfig 설정 분리/OrderCartConsumer에서 토픽명 하드코딩 제거
---

### ✅ 테스트 및 검증 내용
> 테스트한 방법, 환경, 결과를 구체적으로 작성해주세요.

- [x] 로컬 환경 테스트 완료
- [ ] Docker 환경 실행 검증
- [x] Postman

---

### 📸 스크린샷 (선택)
> UI나 응답 결과 캡처가 있다면 첨부해주세요.

---

### 💬 기타 참고 사항
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **신기능**
  * 중앙 구성 서버(Spring Cloud Config) 연동으로 환경 설정 중앙화 지원
  * 애플리케이션 모니터링을 위한 Actuator 추가

* **개선사항**
  * Kafka 소비자 동작 조정(가장 이른 오프셋부터 처리, 폴링 레코드 수 제한)
  * Kafka 토픽을 환경설정으로 동적으로 구성 가능
  * 개발 환경 설정이 외부 구성 저장소로 이동

* **변경**
  * Redis 관련 의존성 제거 (Redis 미사용)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->