### PR TITLE
승인된 결제 재요청시 성공응답 처리

### DIFF
--- a/payment-service/src/main/java/com/destiny/paymentservice/application/service/PaymentServiceImpl.java
+++ b/payment-service/src/main/java/com/destiny/paymentservice/application/service/PaymentServiceImpl.java
@@ -57,7 +57,7 @@ public class PaymentServiceImpl implements PaymentService {
                 }
                 if (findPayment.get().getPaymentStatus().equals(PaymentStatus.PAID)) {
                     // PAID 상태: 이미 최종 결제 완료 (중복 결제 시도 방지)
-                    throw new BizException(PaymentErrorCode.PAYMENT_ALREADY_APPROVED);
+                    return PaymentResponse.fromEntity(findPayment.get());
                 }
             }
 

--- a/payment-service/src/main/java/com/destiny/paymentservice/presentation/code/PaymentSuccessCode.java
+++ b/payment-service/src/main/java/com/destiny/paymentservice/presentation/code/PaymentSuccessCode.java
@@ -11,7 +11,8 @@ public enum PaymentSuccessCode implements ResponseCode {
     PAYMENT_CANCEL_SUCCESS(HttpStatus.OK, "PAYM-003", "결제 취소가 완료되었습니다."),
     PAYMENT_INQUIRY_SUCCESS(HttpStatus.OK, "PAYM-004", "결제 조회가 완료되었습니다."),
     PAYMENT_ALL_INQUIRY_SUCCESS(HttpStatus.OK, "PAYM-005", "결제 목록 조회가 완료되었습니다."),
-    PAYMENT_PARTIAL_CANCEL_SUCCESS(HttpStatus.OK, "PAYM-006", "부분 취소가 완료되었습니다.");
+    PAYMENT_PARTIAL_CANCEL_SUCCESS(HttpStatus.OK, "PAYM-006", "부분 취소가 완료되었습니다."),
+    PAYMENT_ALREADY_COMPLETED(HttpStatus.OK, "PAYM-007", "이미 결제가 완료된 주문입니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/payment-service/src/main/java/com/destiny/paymentservice/presentation/controller/PaymentController.java
+++ b/payment-service/src/main/java/com/destiny/paymentservice/presentation/controller/PaymentController.java
@@ -3,6 +3,7 @@ package com.destiny.paymentservice.presentation.controller;
 import com.destiny.global.response.ApiResponse;
 import com.destiny.global.response.PageResponseDto;
 import com.destiny.paymentservice.application.service.PaymentService;
+import com.destiny.paymentservice.domain.vo.PaymentStatus;
 import com.destiny.paymentservice.infrastructure.messaging.event.command.PaymentCommand;
 import com.destiny.paymentservice.infrastructure.security.auth.CustomUserDetails;
 import com.destiny.paymentservice.presentation.code.PaymentSuccessCode;
@@ -34,6 +35,9 @@ public class PaymentController {
     @PostMapping("/request")
     public ResponseEntity<ApiResponse<PaymentResponse>> requestPayment(@Valid @RequestBody PaymentCommand request) {
         PaymentResponse response = paymentService.requestPayment(request);
+        if (response.paymentStatus().equals(PaymentStatus.PAID)) {
+            return ResponseEntity.ok(ApiResponse.success(PaymentSuccessCode.PAYMENT_ALREADY_COMPLETED, response));
+        }
         return ResponseEntity.ok(ApiResponse.success(PaymentSuccessCode.PAYMENT_REQUEST_SUCCESS, response));
     }
 

--- a/payment-service/src/main/java/com/destiny/paymentservice/presentation/controller/PaymentController.java
+++ b/payment-service/src/main/java/com/destiny/paymentservice/presentation/controller/PaymentController.java
@@ -35,7 +35,7 @@ public class PaymentController {
     @PostMapping("/request")
     public ResponseEntity<ApiResponse<PaymentResponse>> requestPayment(@Valid @RequestBody PaymentCommand request) {
         PaymentResponse response = paymentService.requestPayment(request);
-        if (response.paymentStatus().equals(PaymentStatus.PAID)) {
+        if (response.paymentStatus() == PaymentStatus.PAID) {
             return ResponseEntity.ok(ApiResponse.success(PaymentSuccessCode.PAYMENT_ALREADY_COMPLETED, response));
         }
         return ResponseEntity.ok(ApiResponse.success(PaymentSuccessCode.PAYMENT_REQUEST_SUCCESS, response));


### PR DESCRIPTION

## 📝 PR 제목
> 승인된 결제 재요청시 성공응답 처리

---

### 🔍 관련 이슈
- Close #165 

---

### ✨ 작업 내용 요약
> 승인된 결제를 재요청시 성공응답 처리로 수정
> PaymentSuccessCode 추가
> 컨트롤러 분기처리


- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명)

---

### ⚙️ 주요 변경 사항
> 주요 코드 변경이나 구조 변동이 있다면 작성해주세요.

- ex) `OrderService` 내 주문 생성 로직 수정
- ex) 배송 경로 조회 API 리팩토링

---

### ✅ 테스트 및 검증 내용
> 테스트한 방법, 환경, 결과를 구체적으로 작성해주세요.

- [ ] 로컬 환경 테스트 완료
- [ ] Docker 환경 실행 검증
- [ ] Postman / Swagger 검증 완료

---

### 📸 스크린샷 (선택)
> UI나 응답 결과 캡처가 있다면 첨부해주세요.

---

### 💬 기타 참고 사항
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 이미 완료된 결제를 재요청할 때 오류 대신 기존 결제 정보를 성공 응답으로 반환하도록 개선
* **기능 개선**
  * 완료된 결제에 대해 HTTP 200과 별도 성공 코드/메시지(PAYMENT_ALREADY_COMPLETED)를 반환하도록 응답 동작을 명확히 함

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->