### PR TITLE
feat/쿠폰 템플릿 상세조회 Redis 캐시 적용

### DIFF
--- a/config-server/src/main/resources/config-repo/coupon-service-dev.yml
+++ b/config-server/src/main/resources/config-repo/coupon-service-dev.yml
@@ -8,6 +8,16 @@ spring:
     username: root
     password: 1234
 
+  cache:
+    type: redis
+
+  data:
+    redis:
+      host: localhost
+      port: 5443
+      password: systempass
+      timeout: 2s
+
   kafka:
     bootstrap-servers: localhost:9092
     consumer:

--- a/coupon-service/build.gradle
+++ b/coupon-service/build.gradle
@@ -57,6 +57,10 @@ dependencies {
     implementation 'org.springframework.kafka:spring-kafka'
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 
+    // cache
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
     implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/coupon-service/src/main/java/com/destiny/couponservice/CouponServiceApplication.java
+++ b/coupon-service/src/main/java/com/destiny/couponservice/CouponServiceApplication.java
@@ -2,7 +2,9 @@ package com.destiny.couponservice;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 
+@EnableCaching
 @SpringBootApplication
 public class CouponServiceApplication {
 

--- a/coupon-service/src/main/java/com/destiny/couponservice/application/service/impl/CouponTemplateServiceImpl.java
+++ b/coupon-service/src/main/java/com/destiny/couponservice/application/service/impl/CouponTemplateServiceImpl.java
@@ -12,15 +12,14 @@ import com.destiny.couponservice.presentation.dto.response.CouponTemplateCreateR
 import com.destiny.couponservice.presentation.dto.response.CouponTemplateDetailResponse;
 import com.destiny.couponservice.presentation.dto.response.CouponTemplateListItemResponse;
 import com.destiny.global.exception.BizException;
-import org.springframework.cache.annotation.CacheEvict;
-import org.springframework.cache.annotation.CachePut;
-import org.springframework.cache.annotation.Cacheable;
-import org.springframework.transaction.annotation.Transactional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -115,7 +114,8 @@ public class CouponTemplateServiceImpl implements CouponTemplateService {
     // 쿠폰템플릿 목록 조회
     @Override
     @Transactional
-    public Page<CouponTemplateListItemResponse> search(CouponTemplateSearchRequest req, Pageable pageable) {
+    public Page<CouponTemplateListItemResponse> search(CouponTemplateSearchRequest req,
+        Pageable pageable) {
         return couponTemplateRepository.search(req, pageable)
             .map(CouponTemplateListItemResponse::from);
     }

--- a/coupon-service/src/main/java/com/destiny/couponservice/application/service/impl/CouponTemplateServiceImpl.java
+++ b/coupon-service/src/main/java/com/destiny/couponservice/application/service/impl/CouponTemplateServiceImpl.java
@@ -12,7 +12,10 @@ import com.destiny.couponservice.presentation.dto.response.CouponTemplateCreateR
 import com.destiny.couponservice.presentation.dto.response.CouponTemplateDetailResponse;
 import com.destiny.couponservice.presentation.dto.response.CouponTemplateListItemResponse;
 import com.destiny.global.exception.BizException;
-import jakarta.transaction.Transactional;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.CachePut;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.transaction.annotation.Transactional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -86,7 +89,8 @@ public class CouponTemplateServiceImpl implements CouponTemplateService {
 
     // 쿠폰템플릿 상세조회
     @Override
-    @Transactional
+    @Cacheable(cacheNames = "couponTemplate", key = "#templateId")
+    @Transactional(readOnly = true)
     public CouponTemplateDetailResponse getTemplate(UUID templateId) {
 
         CouponTemplate template = couponTemplateRepository.findById(templateId)
@@ -119,6 +123,7 @@ public class CouponTemplateServiceImpl implements CouponTemplateService {
 
     //쿠폰 템플릿 수정
     @Override
+    @CacheEvict(cacheNames = "couponTemplate", key = "#templateId")
     @Transactional
     public CouponTemplateDetailResponse update(UUID templateId, CouponTemplateUpdateRequest req) {
 
@@ -154,6 +159,7 @@ public class CouponTemplateServiceImpl implements CouponTemplateService {
     }
 
     @Override
+    @CacheEvict(cacheNames = "couponTemplate", key = "#templateId")
     @Transactional
     public void delete(UUID templateId) {
 

--- a/coupon-service/src/main/java/com/destiny/couponservice/infrastructure/config/Redis/RedisCacheConfig.java
+++ b/coupon-service/src/main/java/com/destiny/couponservice/infrastructure/config/Redis/RedisCacheConfig.java
@@ -1,9 +1,9 @@
-package com.destiny.couponservice.infrastructure.config;
+package com.destiny.couponservice.infrastructure.config.Redis;
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.databind.jsontype.impl.LaissezFaireSubTypeValidator;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.time.Duration;
 import org.springframework.cache.annotation.EnableCaching;
@@ -28,9 +28,14 @@ public class RedisCacheConfig {
         om.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
 
         om.activateDefaultTyping(
-            LaissezFaireSubTypeValidator.instance,
+            BasicPolymorphicTypeValidator.builder()
+                .allowIfBaseType(Object.class)
+                .allowIfSubType("com.destiny")
+                .allowIfSubType("java.util")
+                .allowIfSubType("java.time")
+                .build(),
             ObjectMapper.DefaultTyping.NON_FINAL,
-            JsonTypeInfo.As.PROPERTY
+            As.PROPERTY
         );
 
         GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(om);

--- a/coupon-service/src/main/java/com/destiny/couponservice/infrastructure/config/jpa/RedisCacheConfig.java
+++ b/coupon-service/src/main/java/com/destiny/couponservice/infrastructure/config/jpa/RedisCacheConfig.java
@@ -1,0 +1,52 @@
+package com.destiny.couponservice.infrastructure.config;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.jsontype.impl.LaissezFaireSubTypeValidator;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.time.Duration;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableCaching
+public class RedisCacheConfig {
+
+    @Bean
+    public RedisCacheManager cacheManager(RedisConnectionFactory connectionFactory) {
+
+        ObjectMapper om = new ObjectMapper();
+        om.registerModule(new JavaTimeModule());
+        om.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+        om.activateDefaultTyping(
+            LaissezFaireSubTypeValidator.instance,
+            ObjectMapper.DefaultTyping.NON_FINAL,
+            JsonTypeInfo.As.PROPERTY
+        );
+
+        GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(om);
+
+        RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
+            .entryTtl(Duration.ofMinutes(10))
+            .serializeKeysWith(
+                RedisSerializationContext.SerializationPair.fromSerializer(
+                    new StringRedisSerializer())
+            )
+            .serializeValuesWith(
+                RedisSerializationContext.SerializationPair.fromSerializer(serializer)
+            );
+
+        return RedisCacheManager.builder(connectionFactory)
+            .cacheDefaults(config)
+            .build();
+    }
+}

--- a/coupon-service/src/main/java/com/destiny/couponservice/presentation/dto/response/CouponTemplateDetailResponse.java
+++ b/coupon-service/src/main/java/com/destiny/couponservice/presentation/dto/response/CouponTemplateDetailResponse.java
@@ -5,10 +5,14 @@ import com.destiny.couponservice.domain.entity.CouponTemplate;
 import com.destiny.couponservice.domain.enums.DiscountType;
 import java.time.LocalDateTime;
 import java.util.UUID;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
+@AllArgsConstructor
 @Builder
 public class CouponTemplateDetailResponse {
 


### PR DESCRIPTION
## 📝 PR 제목
> 쿠폰 템플릿 상세조회 redis 적용

---

### 🔍 관련 이슈
- Close #189 

---

### ✨ 작업 내용 요약
>쿠폰 템플릿 단건 조회 성능 개선을 위해 Redis 기반 캐시를 적용했습니다

- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명)

---

### ⚙️ 주요 변경 사항
> 쿠폰 템플릿 단건 조회 API(GET /v1/coupon-templates/{templateId}) 에 Redis 캐시 적용
> Spring Cache Abstraction(@Cacheable) 사용

RedisCacheManager 커스터마이징
- JSON 직렬화(GenericJackson2JsonRedisSerializer) 적용
- LocalDateTime 처리를 위한 JavaTimeModule 등록
- 캐시 TTL 10분 설정
- DTO(CouponTemplateDetailResponse) 역직렬화를 위한 기본 생성자 추가


---

### ✅ 테스트 및 검증 내용
- 동일 templateId로 첫 요청 시 DB 조회 후 Redis 캐시 저장 확인
- 두 번째 요청부터 DB 조회 없이 Redis 캐시 Hit 확인
- 수정/삭제 시 캐시 무효화 정상 동작 확인 (CacheEvict)

- [ ] 로컬 환경 테스트 완료
- [ ] Docker 환경 실행 검증
- [ ] Postman / Swagger 검증 완료

---

### 📸 스크린샷 (선택)
> UI나 응답 결과 캡처가 있다면 첨부해주세요.

---

### 💬 기타 참고 사항
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * Redis 캐싱을 통한 쿠폰 템플릿 조회 성능 향상
  * 템플릿 업데이트 및 삭제 시 자동 캐시 갱신 기능 추가
  * 캐시 항목 10분 자동 만료 설정

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->