### PR TITLE
Feat/saga retry 195

### DIFF
--- a/config-server/src/main/resources/config-repo/gateway-dev.yml
+++ b/config-server/src/main/resources/config-repo/gateway-dev.yml
@@ -47,6 +47,10 @@ spring:
               uri: lb://CART-SERVICE
               predicates:
                 - Path=/v*/carts/**
+            - id: saga-orchestrator
+              uri: lb://SAGA-ORCHESTRATOR
+              predicates:
+                - Path=/v*/sagas/**
 
   data:
     redis:

--- a/order-service/src/main/java/com/destiny/orderservice/infrastructure/messaging/event/outbound/OrderCreateRequestEvent.java
+++ b/order-service/src/main/java/com/destiny/orderservice/infrastructure/messaging/event/outbound/OrderCreateRequestEvent.java
@@ -7,7 +7,7 @@ import java.util.UUID;
 public record OrderCreateRequestEvent(
     UUID cartId,
     UUID orderId,
-    Long userId,
+    UUID userId,
     UUID couponId,
     List<OrderItemCreateRequestEvent> items
 ) {
@@ -15,7 +15,7 @@ public record OrderCreateRequestEvent(
         return new OrderCreateRequestEvent(
             cartId,
             order.getOrderId(),
-            1L,
+            order.getUserId(),
             order.getCouponId(),
             order.getItems().stream()
                 .map(OrderItemCreateRequestEvent::from)

--- a/order-service/src/main/java/com/destiny/orderservice/infrastructure/messaging/event/outbound/OrderCreateRequestEvent.java
+++ b/order-service/src/main/java/com/destiny/orderservice/infrastructure/messaging/event/outbound/OrderCreateRequestEvent.java
@@ -7,7 +7,7 @@ import java.util.UUID;
 public record OrderCreateRequestEvent(
     UUID cartId,
     UUID orderId,
-    UUID userId,
+    Long userId,
     UUID couponId,
     List<OrderItemCreateRequestEvent> items
 ) {
@@ -15,7 +15,7 @@ public record OrderCreateRequestEvent(
         return new OrderCreateRequestEvent(
             cartId,
             order.getOrderId(),
-            order.getUserId(),
+            1L,
             order.getCouponId(),
             order.getItems().stream()
                 .map(OrderItemCreateRequestEvent::from)

--- a/saga-orchestrator/build.gradle
+++ b/saga-orchestrator/build.gradle
@@ -25,11 +25,17 @@ repositories {
 }
 
 dependencies {
+    implementation 'com.github.team-destiny:destiny-global:0.0.2'
+
     implementation 'com.vladmihalcea:hibernate-types-60:2.21.1'
+
+    implementation 'com.auth0:java-jwt:4.4.0'
 
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.kafka:spring-kafka'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    testImplementation 'org.springframework.security:spring-security-test'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'org.postgresql:postgresql'

--- a/saga-orchestrator/build.gradle
+++ b/saga-orchestrator/build.gradle
@@ -3,6 +3,9 @@ plugins {
     id 'org.springframework.boot' version '3.5.8'
     id 'io.spring.dependency-management' version '1.1.7'
 }
+ext {
+    springCloudVersion = "2025.0.0"
+}
 
 group = 'com.destiny'
 version = '0.0.1-SNAPSHOT'
@@ -22,6 +25,7 @@ configurations {
 
 repositories {
     mavenCentral()
+    maven { url 'https://jitpack.io'}
 }
 
 dependencies {
@@ -35,6 +39,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.kafka:spring-kafka'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
     testImplementation 'org.springframework.security:spring-security-test'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
@@ -43,6 +48,11 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.kafka:spring-kafka-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:$springCloudVersion"
+    }
 }
 
 tasks.named('test') {

--- a/saga-orchestrator/src/main/java/com/destiny/sagaorchestrator/SagaOrchestratorApplication.java
+++ b/saga-orchestrator/src/main/java/com/destiny/sagaorchestrator/SagaOrchestratorApplication.java
@@ -5,7 +5,6 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
-@EnableJpaAuditing
 public class SagaOrchestratorApplication {
 
     public static void main(String[] args) {

--- a/saga-orchestrator/src/main/java/com/destiny/sagaorchestrator/application/service/SagaService.java
+++ b/saga-orchestrator/src/main/java/com/destiny/sagaorchestrator/application/service/SagaService.java
@@ -1,0 +1,31 @@
+package com.destiny.sagaorchestrator.application.service;
+
+import com.destiny.global.code.CommonErrorCode;
+import com.destiny.global.exception.BizException;
+import com.destiny.sagaorchestrator.domain.entity.SagaState;
+import com.destiny.sagaorchestrator.domain.repository.SagaRepository;
+import com.destiny.sagaorchestrator.infrastructure.auth.CustomUserDetails;
+import com.destiny.sagaorchestrator.presentation.dto.response.SagaResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SagaService {
+
+    private final SagaRepository sagaRepository;
+
+    public List<SagaResponse> sagaLogs(CustomUserDetails customUserDetails) {
+
+        if (!customUserDetails.getUserRole().equalsIgnoreCase("MASTER")) {
+            throw new BizException(CommonErrorCode.ACCESS_DENIED);
+        }
+
+        List<SagaState> logs = sagaRepository.findAll();
+
+        return logs.stream()
+            .map(SagaResponse::from)
+            .toList();
+    }
+}

--- a/saga-orchestrator/src/main/java/com/destiny/sagaorchestrator/application/service/SagaService.java
+++ b/saga-orchestrator/src/main/java/com/destiny/sagaorchestrator/application/service/SagaService.java
@@ -2,9 +2,12 @@ package com.destiny.sagaorchestrator.application.service;
 
 import com.destiny.global.code.CommonErrorCode;
 import com.destiny.global.exception.BizException;
+import com.destiny.sagaorchestrator.domain.entity.SagaDlqMessage;
 import com.destiny.sagaorchestrator.domain.entity.SagaState;
+import com.destiny.sagaorchestrator.domain.repository.SagaDlqRepository;
 import com.destiny.sagaorchestrator.domain.repository.SagaRepository;
 import com.destiny.sagaorchestrator.infrastructure.auth.CustomUserDetails;
+import com.destiny.sagaorchestrator.presentation.dto.response.SagaDlqResponse;
 import com.destiny.sagaorchestrator.presentation.dto.response.SagaResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -15,17 +18,34 @@ import org.springframework.stereotype.Service;
 public class SagaService {
 
     private final SagaRepository sagaRepository;
+    private final SagaDlqRepository sagaDlqRepository;
 
     public List<SagaResponse> sagaLogs(CustomUserDetails customUserDetails) {
 
-        if (!customUserDetails.getUserRole().equalsIgnoreCase("MASTER")) {
-            throw new BizException(CommonErrorCode.ACCESS_DENIED);
-        }
+        isAdmin(customUserDetails);
 
         List<SagaState> logs = sagaRepository.findAll();
 
         return logs.stream()
             .map(SagaResponse::from)
             .toList();
+    }
+
+    public List<SagaDlqResponse> dlqLogs(CustomUserDetails customUserDetails) {
+
+        isAdmin(customUserDetails);
+
+        List<SagaDlqMessage> logs = sagaDlqRepository.findAll();
+
+        return logs.stream()
+            .map(SagaDlqResponse::from)
+            .toList();
+    }
+
+    private void isAdmin(CustomUserDetails customUserDetails) {
+
+        if (!customUserDetails.getUserRole().equalsIgnoreCase("MASTER")) {
+            throw new BizException(CommonErrorCode.ACCESS_DENIED);
+        }
     }
 }

--- a/saga-orchestrator/src/main/java/com/destiny/sagaorchestrator/domain/entity/SagaDlqMessage.java
+++ b/saga-orchestrator/src/main/java/com/destiny/sagaorchestrator/domain/entity/SagaDlqMessage.java
@@ -102,7 +102,8 @@ public class SagaDlqMessage {
         Map<String, Object> headers
     ) {
         SagaDlqMessage message = new SagaDlqMessage();
-        message.originalTopic = record.topic();
+        message.originalTopic = getHeaderAsString(
+            headers, KafkaHeaders.DLT_ORIGINAL_TOPIC);
         message.dlqTopic = record.topic();
         message.partitionNumber = record.partition();
         message.offsetNumber = record.offset();

--- a/saga-orchestrator/src/main/java/com/destiny/sagaorchestrator/domain/entity/SagaDlqMessage.java
+++ b/saga-orchestrator/src/main/java/com/destiny/sagaorchestrator/domain/entity/SagaDlqMessage.java
@@ -1,0 +1,107 @@
+package com.destiny.sagaorchestrator.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "p_saga_dlq_message")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SagaDlqMessage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(nullable = false, length = 255)
+    private String originalTopic;
+
+    @Column(nullable = false, length = 255)
+    private String dlqTopic;
+
+    @Column(nullable = false)
+    private Integer partitionNumber;
+
+    @Column(nullable = false)
+    private Integer offsetNumber;
+
+    @Column(nullable = false, length = 255)
+    private String consumerGroup;
+
+    @Column
+    private String messageKey;
+
+    @Column(nullable = false)
+    private String messagePayload;
+
+    @Column(nullable = false, length = 255)
+    private String exceptionType;
+
+    @Column(length = 1000)
+    private String exceptionMessage;
+
+    @Column(length = 4000)
+    private String stacktrace;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private SagaDlqStatus status;
+
+    @Column(nullable = false)
+    private Integer retryCount;
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    private LocalDateTime processedAt;
+
+    public static SagaDlqMessage of(
+        String originalTopic,
+        String dlqTopic,
+        Integer partitionNumber,
+        Integer offsetNumber,
+        String consumerGroup,
+        String messageKey,
+        String messagePayload,
+        String exceptionMessage,
+        String stacktrace
+    ) {
+        SagaDlqMessage message = new SagaDlqMessage();
+        message.originalTopic = originalTopic;
+        message.dlqTopic = dlqTopic;
+        message.partitionNumber = partitionNumber;
+        message.offsetNumber = offsetNumber;
+        message.consumerGroup = consumerGroup;
+        message.messageKey = messageKey;
+        message.messagePayload = messagePayload;
+        message.exceptionMessage = exceptionMessage;
+        message.stacktrace = stacktrace;
+        message.status = SagaDlqStatus.PENDING;
+        message.retryCount = 0;
+        message.createdAt = LocalDateTime.now();
+        return message;
+    }
+
+    public void markRetry() {
+        this.status = SagaDlqStatus.RETRY;
+        this.retryCount++;
+        this.processedAt = LocalDateTime.now();
+    }
+
+    public void markDropped() {
+        this.status = SagaDlqStatus.DROPPED;
+        this.processedAt = LocalDateTime.now();
+    }
+
+}

--- a/saga-orchestrator/src/main/java/com/destiny/sagaorchestrator/domain/entity/SagaDlqStatus.java
+++ b/saga-orchestrator/src/main/java/com/destiny/sagaorchestrator/domain/entity/SagaDlqStatus.java
@@ -1,0 +1,8 @@
+package com.destiny.sagaorchestrator.domain.entity;
+
+public enum SagaDlqStatus {
+
+    PENDING,
+    RETRY,
+    DROPPED
+}

--- a/saga-orchestrator/src/main/java/com/destiny/sagaorchestrator/domain/repository/SagaDlqRepository.java
+++ b/saga-orchestrator/src/main/java/com/destiny/sagaorchestrator/domain/repository/SagaDlqRepository.java
@@ -1,0 +1,5 @@
+package com.destiny.sagaorchestrator.domain.repository;
+
+public interface SagaDlqRepository {
+
+}

--- a/saga-orchestrator/src/main/java/com/destiny/sagaorchestrator/domain/repository/SagaDlqRepository.java
+++ b/saga-orchestrator/src/main/java/com/destiny/sagaorchestrator/domain/repository/SagaDlqRepository.java
@@ -1,8 +1,12 @@
 package com.destiny.sagaorchestrator.domain.repository;
 
 import com.destiny.sagaorchestrator.domain.entity.SagaDlqMessage;
+import java.util.List;
 
 public interface SagaDlqRepository {
 
     void save(SagaDlqMessage message);
+
+    List<SagaDlqMessage> findAll();
+
 }

--- a/saga-orchestrator/src/main/java/com/destiny/sagaorchestrator/domain/repository/SagaDlqRepository.java
+++ b/saga-orchestrator/src/main/java/com/destiny/sagaorchestrator/domain/repository/SagaDlqRepository.java
@@ -1,5 +1,8 @@
 package com.destiny.sagaorchestrator.domain.repository;
 
+import com.destiny.sagaorchestrator.domain.entity.SagaDlqMessage;
+
 public interface SagaDlqRepository {
 
+    void save(SagaDlqMessage message);
 }

--- a/saga-orchestrator/src/main/java/com/destiny/sagaorchestrator/domain/repository/SagaRepository.java
+++ b/saga-orchestrator/src/main/java/com/destiny/sagaorchestrator/domain/repository/SagaRepository.java
@@ -1,6 +1,7 @@
 package com.destiny.sagaorchestrator.domain.repository;
 
 import com.destiny.sagaorchestrator.domain.entity.SagaState;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -11,4 +12,7 @@ public interface SagaRepository {
     SagaState findByOrderId(UUID uuid);
 
     SagaState findById(UUID uuid);
+
+    List<SagaState> findAll();
+
 }

--- a/saga-orchestrator/src/main/java/com/destiny/sagaorchestrator/infrastructure/auth/CustomAccessDeniedHandler.java
+++ b/saga-orchestrator/src/main/java/com/destiny/sagaorchestrator/infrastructure/auth/CustomAccessDeniedHandler.java
@@ -1,0 +1,31 @@
+package com.destiny.sagaorchestrator.infrastructure.auth;
+
+import com.destiny.global.code.CommonErrorCode;
+import com.destiny.global.response.ApiResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response,
+        AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().print(objectMapper.writeValueAsString(
+            ApiResponse.error(CommonErrorCode.ACCESS_DENIED)));
+    }
+}

--- a/saga-orchestrator/src/main/java/com/destiny/sagaorchestrator/infrastructure/auth/CustomAuthenticationEntryPoint.java
+++ b/saga-orchestrator/src/main/java/com/destiny/sagaorchestrator/infrastructure/auth/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,31 @@
+package com.destiny.sagaorchestrator.infrastructure.auth;
+
+import com.destiny.global.code.CommonErrorCode;
+import com.destiny.global.response.ApiResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+        AuthenticationException authException) throws IOException, ServletException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().print(objectMapper.writeValueAsString(
+            ApiResponse.error(CommonErrorCode.UNAUTHORIZED)
+        ));
+    }
+}

--- a/saga-orchestrator/src/main/java/com/destiny/sagaorchestrator/infrastructure/auth/CustomUserDetails.java
+++ b/saga-orchestrator/src/main/java/com/destiny/sagaorchestrator/infrastructure/auth/CustomUserDetails.java
@@ -1,0 +1,73 @@
+package com.destiny.sagaorchestrator.infrastructure.auth;
+
+import com.auth0.jwt.interfaces.DecodedJWT;
+import com.destiny.global.code.CommonErrorCode;
+import com.destiny.global.exception.BizException;
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+@Getter
+public class CustomUserDetails implements UserDetails {
+
+    private UUID userId;
+    private String username;
+    private String email;
+    private String accessJwt;
+    private String userRole;
+
+    public CustomUserDetails() {};
+
+    public static CustomUserDetails of(DecodedJWT decodedJwt) {
+        CustomUserDetails customUserDetails = new CustomUserDetails();
+        String userIdStr = decodedJwt.getClaim("userId").asString();
+        if (userIdStr == null) {
+            throw new BizException(CommonErrorCode.MISSING_PARAMETER);
+        }
+        customUserDetails.userId = UUID.fromString(userIdStr);
+        customUserDetails.username = decodedJwt.getClaim("username").asString();
+        customUserDetails.email = decodedJwt.getClaim("email").asString();
+        customUserDetails.accessJwt = decodedJwt.getToken();
+        customUserDetails.userRole = decodedJwt.getClaim("userRole").asString();
+        return customUserDetails;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority("ROLE_" + userRole));
+    }
+
+    @Override
+    public String getUsername() {
+        return username;
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return UserDetails.super.isAccountNonExpired();
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return UserDetails.super.isAccountNonLocked();
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return UserDetails.super.isCredentialsNonExpired();
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return UserDetails.super.isEnabled();
+    }
+}

--- a/saga-orchestrator/src/main/java/com/destiny/sagaorchestrator/infrastructure/auth/CustomUserDetailsService.java
+++ b/saga-orchestrator/src/main/java/com/destiny/sagaorchestrator/infrastructure/auth/CustomUserDetailsService.java
@@ -1,0 +1,19 @@
+package com.destiny.sagaorchestrator.infrastructure.auth;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CustomUserDetailsService implements UserDetailsService {
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        throw new UsernameNotFoundException("현재 사용하지 않는 인증 방식입니다.");
+    }
+}

--- a/saga-orchestrator/src/main/java/com/destiny/sagaorchestrator/infrastructure/config/CustomExceptionHandler.java
+++ b/saga-orchestrator/src/main/java/com/destiny/sagaorchestrator/infrastructure/config/CustomExceptionHandler.java
@@ -1,0 +1,9 @@
+package com.destiny.sagaorchestrator.infrastructure.config;
+
+import com.destiny.global.exception.GlobalExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class CustomExceptionHandler extends GlobalExceptionHandler {
+
+}

--- a/saga-orchestrator/src/main/java/com/destiny/sagaorchestrator/infrastructure/config/JpaAuditing.java
+++ b/saga-orchestrator/src/main/java/com/destiny/sagaorchestrator/infrastructure/config/JpaAuditing.java
@@ -1,0 +1,10 @@
+package com.destiny.sagaorchestrator.infrastructure.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditing {
+
+}

--- a/saga-orchestrator/src/main/java/com/destiny/sagaorchestrator/infrastructure/config/SecurityAuditorAware.java
+++ b/saga-orchestrator/src/main/java/com/destiny/sagaorchestrator/infrastructure/config/SecurityAuditorAware.java
@@ -1,0 +1,29 @@
+package com.destiny.sagaorchestrator.infrastructure.config;
+
+import com.destiny.sagaorchestrator.infrastructure.auth.CustomUserDetails;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SecurityAuditorAware implements AuditorAware<UUID> {
+
+    @Override
+    public Optional<UUID> getCurrentAuditor() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return Optional.empty();
+        }
+
+        Object principal = authentication.getPrincipal();
+        if (principal instanceof CustomUserDetails userDetails) {
+            return Optional.of(userDetails.getUserId());
+        }
+
+        return Optional.empty();
+    }
+}

--- a/saga-orchestrator/src/main/java/com/destiny/sagaorchestrator/infrastructure/config/SecurityConfig.java
+++ b/saga-orchestrator/src/main/java/com/destiny/sagaorchestrator/infrastructure/config/SecurityConfig.java
@@ -1,0 +1,53 @@
+package com.destiny.sagaorchestrator.infrastructure.config;
+
+import com.destiny.sagaorchestrator.infrastructure.auth.CustomAccessDeniedHandler;
+import com.destiny.sagaorchestrator.infrastructure.auth.CustomAuthenticationEntryPoint;
+import com.destiny.sagaorchestrator.infrastructure.filter.JwtAuthorizationFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    // 인증 안 된 사용자가 api 접근했을 때(401) 응답 처리
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+    // 인증된 사용자가 권한이 부족할 때(403) 응답 처리
+    private final CustomAccessDeniedHandler customAccessDeniedHandler;
+    private final JwtAuthorizationFilter jwtAuthorizationFilter;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
+        httpSecurity.csrf(csrf -> csrf.disable());
+        httpSecurity.formLogin(form -> form.disable());
+        httpSecurity.httpBasic(basic -> basic.disable());
+        httpSecurity.logout(logout -> logout.disable());
+        httpSecurity.sessionManagement(session ->
+            session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
+        // 예외 처리 커스터마이징
+        httpSecurity.exceptionHandling(handler -> handler
+            .authenticationEntryPoint(customAuthenticationEntryPoint)
+            .accessDeniedHandler(customAccessDeniedHandler));
+
+        // JWT 필터 등록 (SecurityContext에 Authentication 세팅)
+        httpSecurity.addFilterBefore(jwtAuthorizationFilter, UsernamePasswordAuthenticationFilter.class);
+
+        httpSecurity.authorizeHttpRequests(authorize -> {
+            // TODO : 접근 권한 부여
+            authorize.anyRequest().authenticated();
+        });
+
+        return httpSecurity.build();
+    }
+
+}

--- a/saga-orchestrator/src/main/java/com/destiny/sagaorchestrator/infrastructure/filter/JwtAuthorizationFilter.java
+++ b/saga-orchestrator/src/main/java/com/destiny/sagaorchestrator/infrastructure/filter/JwtAuthorizationFilter.java
@@ -1,0 +1,53 @@
+package com.destiny.sagaorchestrator.infrastructure.filter;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import com.destiny.sagaorchestrator.infrastructure.auth.CustomUserDetails;
+import com.destiny.sagaorchestrator.infrastructure.jwt.JwtProperties;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j(topic = "토큰 권한 인가")
+public class JwtAuthorizationFilter extends OncePerRequestFilter {
+
+    private final JwtProperties jwtProperties;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+        throws ServletException, IOException {
+
+        String authorizationHeader = request.getHeader(jwtProperties.getAccessHeaderName());
+        if (!StringUtils.hasText(authorizationHeader) || !authorizationHeader.startsWith(jwtProperties.getHeaderPrefix())) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String accessJwt = authorizationHeader.substring(jwtProperties.getHeaderPrefix().length()).trim();
+        DecodedJWT decodedAccessJwt = JWT.decode(accessJwt);
+
+        CustomUserDetails userDetails;
+        try {
+            userDetails = CustomUserDetails.of(decodedAccessJwt);
+        } catch (RuntimeException exception) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        UsernamePasswordAuthenticationToken authenticationToken =
+            new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+        filterChain.doFilter(request, response);
+    }
+}

--- a/saga-orchestrator/src/main/java/com/destiny/sagaorchestrator/infrastructure/jwt/JwtProperties.java
+++ b/saga-orchestrator/src/main/java/com/destiny/sagaorchestrator/infrastructure/jwt/JwtProperties.java
@@ -1,0 +1,24 @@
+package com.destiny.sagaorchestrator.infrastructure.jwt;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Component
+public class JwtProperties {
+
+    private final String accessHeaderName;
+    private final String headerPrefix;
+    private final String accessSubject;
+
+    public JwtProperties(
+        @Value("${jwt.access-header-name}") String accessHeaderName,
+        @Value("${jwt.header-prefix}") String headerPrefix,
+        @Value("${jwt.access-subject}") String accessSubject
+    ) {
+        this.accessHeaderName = accessHeaderName;
+        this.headerPrefix = headerPrefix;
+        this.accessSubject = accessSubject;
+    }
+}

--- a/saga-orchestrator/src/main/java/com/destiny/sagaorchestrator/infrastructure/messaging/config/KafkaConsumerConfig.java
+++ b/saga-orchestrator/src/main/java/com/destiny/sagaorchestrator/infrastructure/messaging/config/KafkaConsumerConfig.java
@@ -10,25 +10,40 @@ import org.springframework.kafka.annotation.EnableKafka;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.listener.CommonErrorHandler;
+import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer;
 
 @EnableKafka
 @Configuration
 public class KafkaConsumerConfig {
 
     @Bean
-    public ConsumerFactory<String, String> consumerFactory() throws  Exception {
+    public ConsumerFactory<String, String> consumerFactory() {
+
         Map<String, Object> properties = new HashMap<>();
+
         properties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
         properties.put(ConsumerConfig.GROUP_ID_CONFIG, "saga-orchestrator");
-        properties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-        properties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+
+        properties.put(
+            ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
+            StringDeserializer.class);
+        properties.put(
+            ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
+            StringDeserializer.class);
+
         return new DefaultKafkaConsumerFactory<>(properties);
     }
 
     @Bean
-    public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory() throws  Exception {
+    public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory(
+        CommonErrorHandler commonErrorHandler) {
+
         ConcurrentKafkaListenerContainerFactory<String, String> factory = new ConcurrentKafkaListenerContainerFactory<>();
+
         factory.setConsumerFactory(consumerFactory());
+        factory.setCommonErrorHandler(commonErrorHandler);
+
         return factory;
     }
 }

--- a/saga-orchestrator/src/main/java/com/destiny/sagaorchestrator/infrastructure/messaging/config/KafkaDlqConfig.java
+++ b/saga-orchestrator/src/main/java/com/destiny/sagaorchestrator/infrastructure/messaging/config/KafkaDlqConfig.java
@@ -1,0 +1,38 @@
+package com.destiny.sagaorchestrator.infrastructure.messaging.config;
+
+import org.apache.kafka.common.TopicPartition;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
+
+@Configuration
+public class KafkaDlqConfig {
+
+    /**
+     * DeadLetterPublishingRecoverer
+     *
+     * Retry를 모두 소진한 메시지를
+     * 어떤 DLQ 토픽으로 보낼지 정의하는 컴포터는이다.
+     *
+     * 이 Bean이 없으면 DLQ는 절대 동작하지 않는다.
+     */
+    @Bean
+    public DeadLetterPublishingRecoverer deadLetterPublishingRecoverer(
+        KafkaTemplate<String, String> kafkaTemplate
+    ) {
+        return new DeadLetterPublishingRecoverer(kafkaTemplate, (record, exception) -> {
+
+            /**
+             * DLQ 토픽 네이밍 규칙
+             *
+             * 원본 토픽 : order-create-request
+             * DLQ 토픽 : order-create-request.dlq
+             */
+            return new TopicPartition(
+                record.topic() + ".DLQ",
+                record.partition()
+            );
+        });
+    }
+}

--- a/saga-orchestrator/src/main/java/com/destiny/sagaorchestrator/infrastructure/messaging/config/KafkaDlqConfig.java
+++ b/saga-orchestrator/src/main/java/com/destiny/sagaorchestrator/infrastructure/messaging/config/KafkaDlqConfig.java
@@ -13,7 +13,7 @@ public class KafkaDlqConfig {
      * DeadLetterPublishingRecoverer
      *
      * Retry를 모두 소진한 메시지를
-     * 어떤 DLQ 토픽으로 보낼지 정의하는 컴포터는이다.
+     * 어떤 DLQ 토픽으로 보낼지 정의하는 컴포넌트이다.
      *
      * 이 Bean이 없으면 DLQ는 절대 동작하지 않는다.
      */

--- a/saga-orchestrator/src/main/java/com/destiny/sagaorchestrator/infrastructure/messaging/config/KafkaErrorHandlerConfig.java
+++ b/saga-orchestrator/src/main/java/com/destiny/sagaorchestrator/infrastructure/messaging/config/KafkaErrorHandlerConfig.java
@@ -1,0 +1,42 @@
+package com.destiny.sagaorchestrator.infrastructure.messaging.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.listener.CommonErrorHandler;
+import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
+import org.springframework.kafka.listener.DefaultErrorHandler;
+import org.springframework.util.backoff.FixedBackOff;
+
+@Configuration
+public class KafkaErrorHandlerConfig {
+
+    /**
+     * CommonErrorHandler
+     *
+     * 메시지 처리 중 예외가 발생했을 때
+     * Kafka가 어떻게 행동할지를 정의.
+     *
+     */
+    @Bean
+    public CommonErrorHandler commonErrorHandler(
+        DeadLetterPublishingRecoverer deadLetterPublishingRecoverer
+    ) {
+
+        /**
+         *  FixedBackOff
+         *
+         *  - interval : 재시도 간격 (ms)
+         *  - maxAttempts : 재시도 횟수
+         *
+         *  이커머스 기준 :
+         *  - 너무 길면 처리 지연 될 거 같음.
+         *  - 너무 짧으면 외부 시스템 회복 전 재시도
+         *
+         *  그래서 500 ms * 3회가 현실적인 타협이라 생각했음.
+         */
+        FixedBackOff backOff = new FixedBackOff(500L, 3L);
+
+        return new DefaultErrorHandler(deadLetterPublishingRecoverer, backOff);
+    }
+
+}

--- a/saga-orchestrator/src/main/java/com/destiny/sagaorchestrator/infrastructure/messaging/consumer/SagaConsumer.java
+++ b/saga-orchestrator/src/main/java/com/destiny/sagaorchestrator/infrastructure/messaging/consumer/SagaConsumer.java
@@ -49,6 +49,7 @@ public class SagaConsumer {
         } catch (JsonProcessingException e) {
 
             log.info("[🔥️ JOIN SAGA FAIL JSON EXCEPTION] - ORDER CREATE : {}", e.getMessage());
+            throw new IllegalStateException("ORDER CREATE JSON PARSE FAIL", e);
         }
     }
 

--- a/saga-orchestrator/src/main/java/com/destiny/sagaorchestrator/infrastructure/messaging/consumer/SagaDlqConsumer.java
+++ b/saga-orchestrator/src/main/java/com/destiny/sagaorchestrator/infrastructure/messaging/consumer/SagaDlqConsumer.java
@@ -1,0 +1,28 @@
+package com.destiny.sagaorchestrator.infrastructure.messaging.consumer;
+
+import com.destiny.sagaorchestrator.domain.entity.SagaDlqMessage;
+import com.destiny.sagaorchestrator.domain.repository.SagaDlqRepository;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.messaging.handler.annotation.Headers;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SagaDlqConsumer {
+
+    private final SagaDlqRepository sagaDlqRepository;
+
+    @KafkaListener(topicPattern = ".*\\.DLQ", groupId = "saga-orchestrator-dlq")
+    public void consumeDlq(
+        ConsumerRecord<String, String> record,
+        @Headers Map<String, Object> headers
+    ) {
+        SagaDlqMessage message = SagaDlqMessage.fromKafka(record, headers);
+
+        sagaDlqRepository.save(message);
+    }
+
+}

--- a/saga-orchestrator/src/main/java/com/destiny/sagaorchestrator/infrastructure/repository/SagaDlqJpaRepository.java
+++ b/saga-orchestrator/src/main/java/com/destiny/sagaorchestrator/infrastructure/repository/SagaDlqJpaRepository.java
@@ -1,0 +1,9 @@
+package com.destiny.sagaorchestrator.infrastructure.repository;
+
+import com.destiny.sagaorchestrator.domain.entity.SagaDlqMessage;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SagaDlqJpaRepository extends JpaRepository<SagaDlqMessage, UUID> {
+
+}

--- a/saga-orchestrator/src/main/java/com/destiny/sagaorchestrator/infrastructure/repository/SagaDlqRepositoryImpl.java
+++ b/saga-orchestrator/src/main/java/com/destiny/sagaorchestrator/infrastructure/repository/SagaDlqRepositoryImpl.java
@@ -1,0 +1,13 @@
+package com.destiny.sagaorchestrator.infrastructure.repository;
+
+import com.destiny.sagaorchestrator.domain.repository.SagaDlqRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class SagaDlqRepositoryImpl implements SagaDlqRepository {
+
+    private final SagaDlqJpaRepository sagaDlqJpaRepository;
+
+}

--- a/saga-orchestrator/src/main/java/com/destiny/sagaorchestrator/infrastructure/repository/SagaDlqRepositoryImpl.java
+++ b/saga-orchestrator/src/main/java/com/destiny/sagaorchestrator/infrastructure/repository/SagaDlqRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.destiny.sagaorchestrator.infrastructure.repository;
 
 import com.destiny.sagaorchestrator.domain.entity.SagaDlqMessage;
 import com.destiny.sagaorchestrator.domain.repository.SagaDlqRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -15,5 +16,11 @@ public class SagaDlqRepositoryImpl implements SagaDlqRepository {
     public void save(SagaDlqMessage message) {
 
         sagaDlqJpaRepository.save(message);
+    }
+
+    @Override
+    public List<SagaDlqMessage> findAll() {
+
+        return sagaDlqJpaRepository.findAll();
     }
 }

--- a/saga-orchestrator/src/main/java/com/destiny/sagaorchestrator/infrastructure/repository/SagaDlqRepositoryImpl.java
+++ b/saga-orchestrator/src/main/java/com/destiny/sagaorchestrator/infrastructure/repository/SagaDlqRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.destiny.sagaorchestrator.infrastructure.repository;
 
+import com.destiny.sagaorchestrator.domain.entity.SagaDlqMessage;
 import com.destiny.sagaorchestrator.domain.repository.SagaDlqRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -10,4 +11,9 @@ public class SagaDlqRepositoryImpl implements SagaDlqRepository {
 
     private final SagaDlqJpaRepository sagaDlqJpaRepository;
 
+    @Override
+    public void save(SagaDlqMessage message) {
+
+        sagaDlqJpaRepository.save(message);
+    }
 }

--- a/saga-orchestrator/src/main/java/com/destiny/sagaorchestrator/infrastructure/repository/SagaRepositoryImpl.java
+++ b/saga-orchestrator/src/main/java/com/destiny/sagaorchestrator/infrastructure/repository/SagaRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.destiny.sagaorchestrator.infrastructure.repository;
 
 import com.destiny.sagaorchestrator.domain.entity.SagaState;
 import com.destiny.sagaorchestrator.domain.repository.SagaRepository;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -28,5 +29,11 @@ public class SagaRepositoryImpl implements SagaRepository {
     public SagaState findById(UUID uuid) {
 
         return sagaJpaRepository.findById(uuid).orElse(null);
+    }
+
+    @Override
+    public List<SagaState> findAll() {
+
+        return sagaJpaRepository.findAll();
     }
 }

--- a/saga-orchestrator/src/main/java/com/destiny/sagaorchestrator/presentation/controller/SagaController.java
+++ b/saga-orchestrator/src/main/java/com/destiny/sagaorchestrator/presentation/controller/SagaController.java
@@ -1,16 +1,34 @@
 package com.destiny.sagaorchestrator.presentation.controller;
 
-import com.destiny.sagaorchestrator.application.service.OrderCreateService;
+import com.destiny.sagaorchestrator.application.service.SagaService;
+import com.destiny.sagaorchestrator.infrastructure.auth.CustomUserDetails;
+import com.destiny.sagaorchestrator.presentation.dto.response.SagaResponse;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/v1/sagas")
 public class SagaController {
 
-    private final OrderCreateService orderCreateService;
+    private final SagaService sagaService;
 
-    // TODO : 사가 로그 조회 마스터 권한.
+    @GetMapping
+    public ResponseEntity<List<SagaResponse>> sagaLogs(
+        @AuthenticationPrincipal CustomUserDetails customUserDetails
+    ) {
 
+        List<SagaResponse> logs = sagaService.sagaLogs(customUserDetails);
+
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(logs);
+    }
 
 }

--- a/saga-orchestrator/src/main/java/com/destiny/sagaorchestrator/presentation/controller/SagaController.java
+++ b/saga-orchestrator/src/main/java/com/destiny/sagaorchestrator/presentation/controller/SagaController.java
@@ -2,6 +2,7 @@ package com.destiny.sagaorchestrator.presentation.controller;
 
 import com.destiny.sagaorchestrator.application.service.SagaService;
 import com.destiny.sagaorchestrator.infrastructure.auth.CustomUserDetails;
+import com.destiny.sagaorchestrator.presentation.dto.response.SagaDlqResponse;
 import com.destiny.sagaorchestrator.presentation.dto.response.SagaResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -23,8 +24,18 @@ public class SagaController {
     public ResponseEntity<List<SagaResponse>> sagaLogs(
         @AuthenticationPrincipal CustomUserDetails customUserDetails
     ) {
-
         List<SagaResponse> logs = sagaService.sagaLogs(customUserDetails);
+
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(logs);
+    }
+
+    @GetMapping("/dlq")
+    public ResponseEntity<List<SagaDlqResponse>> dlqLogs(
+        @AuthenticationPrincipal CustomUserDetails customUserDetails
+    ) {
+        List<SagaDlqResponse> logs = sagaService.dlqLogs(customUserDetails);
 
         return ResponseEntity
             .status(HttpStatus.OK)

--- a/saga-orchestrator/src/main/java/com/destiny/sagaorchestrator/presentation/dto/response/SagaDlqResponse.java
+++ b/saga-orchestrator/src/main/java/com/destiny/sagaorchestrator/presentation/dto/response/SagaDlqResponse.java
@@ -1,0 +1,41 @@
+package com.destiny.sagaorchestrator.presentation.dto.response;
+
+import com.destiny.sagaorchestrator.domain.entity.SagaDlqMessage;
+import com.destiny.sagaorchestrator.domain.entity.SagaDlqStatus;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record SagaDlqResponse(
+    UUID dlqId,
+    String originalTopic,
+    String dlqTopic,
+    Integer partitionNumber,
+    Long offsetNumber,
+    String consumerGroup,
+    String messageKey,
+    String messagePayload,
+    String exceptionType,
+    String exceptionMessage,
+    SagaDlqStatus status,
+    Integer retryCount,
+    LocalDateTime createdAt
+) {
+
+    public static SagaDlqResponse from(SagaDlqMessage message) {
+        return new SagaDlqResponse(
+            message.getId(),
+            message.getOriginalTopic(),
+            message.getDlqTopic(),
+            message.getPartitionNumber(),
+            message.getOffsetNumber(),
+            message.getConsumerGroup(),
+            message.getMessageKey(),
+            message.getMessagePayload(),
+            message.getExceptionType(),
+            message.getExceptionMessage(),
+            message.getStatus(),
+            message.getRetryCount(),
+            message.getCreatedAt()
+        );
+    }
+}

--- a/saga-orchestrator/src/main/java/com/destiny/sagaorchestrator/presentation/dto/response/SagaResponse.java
+++ b/saga-orchestrator/src/main/java/com/destiny/sagaorchestrator/presentation/dto/response/SagaResponse.java
@@ -1,0 +1,32 @@
+package com.destiny.sagaorchestrator.presentation.dto.response;
+
+import com.destiny.sagaorchestrator.domain.entity.SagaState;
+import com.destiny.sagaorchestrator.domain.entity.SagaStatus;
+import com.destiny.sagaorchestrator.domain.entity.SagaStep;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record SagaResponse(
+
+    UUID sagaId,
+    UUID userId,
+    Integer finalAmount,
+    SagaStatus status,
+    SagaStep step,
+    String failureReason,
+    LocalDateTime createdAt
+
+) {
+
+    public static SagaResponse from(SagaState sagaState) {
+        return new SagaResponse(
+            sagaState.getSagaId(),
+            sagaState.getUserId(),
+            sagaState.getFinalAmount(),
+            sagaState.getStatus(),
+            sagaState.getStep(),
+            sagaState.getFailureReason(),
+            sagaState.getCreatedAt()
+        );
+    }
+}

--- a/saga-orchestrator/src/main/resources/application.yml
+++ b/saga-orchestrator/src/main/resources/application.yml
@@ -34,3 +34,13 @@ jwt:
   access-header-name: Authorization
   header-prefix: Bearer
   access-subject: AccessToken
+
+eureka:
+  instance:
+    prefer-ip-address: true
+    hostname: localhost
+  client:
+    service-url:
+      defaultZone: http://localhost:8761/eureka/
+    register-with-eureka: true
+    fetch-registry: true

--- a/saga-orchestrator/src/main/resources/application.yml
+++ b/saga-orchestrator/src/main/resources/application.yml
@@ -29,3 +29,8 @@ logging:
     org.apache.kafka.common.network: WARN
     org.apache.kafka.clients.FetchSessionHandler: WARN
     org.apache.kafka.clients.Metadata: WARN
+
+jwt:
+  access-header-name: Authorization
+  header-prefix: Bearer
+  access-subject: AccessToken


### PR DESCRIPTION
## 📝 PR 제목
> 사가 서비스 retry , DLQ 적용 

---

### 🔍 관련 이슈
- Close #195 

---

### ✨ 작업 내용 요약
> 어떤 변경이 이루어졌는지 간단히 설명해주세요.
사가 서비스에서 서비스 간 통신 할 때 성공하지 못하는 메시지 처리를 retry 3번 시도하고, 
3번 시도 이후에도 실패한다면 DLQ토픽으로 전송되며 DLQ테이블에 따로 저장

- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타 (설명)

---

### ⚙️ 주요 변경 사항
> 주요 코드 변경이나 구조 변동이 있다면 작성해주세요.

- ex) `OrderService` 내 주문 생성 로직 수정
- ex) 배송 경로 조회 API 리팩토링

---

### ✅ 테스트 및 검증 내용
> 테스트한 방법, 환경, 결과를 구체적으로 작성해주세요.

- [ ] 로컬 환경 테스트 완료
- [ ] Docker 환경 실행 검증
- [ ] Postman / Swagger 검증 완료

---

### 📸 스크린샷 (선택)
> UI나 응답 결과 캡처가 있다면 첨부해주세요.

---

### 💬 기타 참고 사항
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * Saga 로그 조회 API 추가 (관리자 전용)
  * 메시지 처리 실패 관련 로그 조회 기능 추가
  * JWT 기반 인증 시스템 구현
  * Saga Orchestrator 마이크로서비스 게이트웨이 라우팅 추가

* **개선 사항**
  * 실패한 메시지 처리를 위한 자동 재시도 및 데드레터 큐 지원
  * 보안 강화를 통한 API 접근 제어 개선
  * 에러 처리 및 응답 표준화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->