### PR TITLE
재고 서비스 단위 테스트 작성

### DIFF
--- a/stock-service/src/test/java/com/destiny/stockservice/application/StockEventHandlerTest.java
+++ b/stock-service/src/test/java/com/destiny/stockservice/application/StockEventHandlerTest.java
@@ -1,0 +1,185 @@
+package com.destiny.stockservice.application;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.destiny.stockservice.application.dto.event.cancel.ConfirmedStockCancelEvent;
+import com.destiny.stockservice.application.dto.event.cancel.StockReservationCancelEvent;
+import com.destiny.stockservice.application.dto.event.reservation.StockReservationEvent;
+import com.destiny.stockservice.application.dto.event.reservation.StockReservationItem;
+import com.destiny.stockservice.application.dto.order.OrderCompletedEvent;
+import com.destiny.stockservice.application.dto.stock.StockCreateEvent;
+import com.destiny.stockservice.application.service.StockReservationService;
+import com.destiny.stockservice.application.service.StockService;
+import com.destiny.stockservice.domain.result.ConfirmedStockCancelResult;
+import com.destiny.stockservice.domain.result.StockReservationCancelResult;
+import com.destiny.stockservice.domain.result.StockReservationResult;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class StockEventHandlerTest {
+
+    @InjectMocks
+    private StockEventHandler stockEventHandler;
+
+    @Mock
+    private StockReservationService stockReservationService;
+
+    @Mock
+    private StockEventPublisher stockEventPublisher;
+
+    @Mock
+    private StockService stockService;
+
+    @Spy
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    @DisplayName("재고 생성 이벤트를 처리한다.")
+    void handleStockCreate() throws Exception {
+        // given
+        StockCreateEvent event = new StockCreateEvent(UUID.randomUUID(), 100);
+        String message = objectMapper.writeValueAsString(event);
+
+        // when
+        stockEventHandler.handleStockCreate(message);
+
+        // then
+        verify(stockService, times(1)).createStock(any(StockCreateEvent.class));
+    }
+
+    @Test
+    @DisplayName("재고 예약 성공 시 성공 이벤트를 발행한다.")
+    void handleStockReservationSuccess() throws Exception {
+        // given
+        UUID orderId = UUID.randomUUID();
+        StockReservationEvent event = new StockReservationEvent(orderId,
+            List.of(new StockReservationItem(UUID.randomUUID(), 1)));
+        String message = objectMapper.writeValueAsString(event);
+
+        given(stockReservationService.reserveStock(any())).willReturn(
+            StockReservationResult.RESERVED);
+
+        // when
+        stockEventHandler.handleStockReservation(message);
+
+        // then
+        verify(stockEventPublisher, times(1)).publishReservationSuccess(anyString());
+    }
+
+    @Test
+    @DisplayName("재고 예약 실패(재고 부족 등) 시 실패 이벤트를 발행한다.")
+    void handleStockReservationFail() throws Exception {
+        // given
+        StockReservationEvent event = new StockReservationEvent(UUID.randomUUID(), List.of());
+        String message = objectMapper.writeValueAsString(event);
+
+        given(stockReservationService.reserveStock(any())).willReturn(
+            StockReservationResult.OUT_OF_STOCK);
+
+        // when
+        stockEventHandler.handleStockReservation(message);
+
+        // then
+        verify(stockEventPublisher, times(1)).publishReservationFail(anyString());
+    }
+
+    @Test
+    @DisplayName("재고 예약 취소 성공 시 성공 이벤트를 발행한다.")
+    void handleStockReservationCancelSuccess() throws Exception {
+        // given
+        UUID sagaId = UUID.randomUUID();
+        UUID orderId = UUID.randomUUID();
+
+        StockReservationCancelEvent event = new StockReservationCancelEvent(
+            sagaId,
+            orderId,
+            List.of(new StockReservationCancelEvent.StockReservationCancelItem(UUID.randomUUID(), 1))
+        );
+        String message = objectMapper.writeValueAsString(event);
+
+        given(stockReservationService.cancelReservedStock(any())).willReturn(
+            StockReservationCancelResult.CANCEL_SUCCEEDED);
+
+        // when
+        stockEventHandler.handleStockReservationCancel(message);
+
+        // then
+        verify(stockEventPublisher, times(1)).publishReservationCancelSuccess(anyString());
+    }
+
+    @Test
+    @DisplayName("확정된 재고 취소 성공 시 성공 이벤트를 발행한다.")
+    void handleConfirmedStockCancelSuccess() throws Exception {
+        // given
+        UUID sagaId = UUID.randomUUID();
+        UUID orderId = UUID.randomUUID();
+
+        ConfirmedStockCancelEvent event = new ConfirmedStockCancelEvent(
+            sagaId,
+            orderId,
+            List.of(new ConfirmedStockCancelEvent.StockCancelItem(UUID.randomUUID(), 1))
+        );
+
+        String message = objectMapper.writeValueAsString(event);
+
+        given(stockReservationService.cancelConfirmedStock(any())).willReturn(
+            ConfirmedStockCancelResult.CANCEL_SUCCEEDED);
+
+        // when
+        stockEventHandler.handleConfirmedStockCancel(message);
+
+        // then
+        verify(stockEventPublisher, times(1)).publishConfirmedStockCancelSuccess(anyString());
+    }
+
+    @Test
+    @DisplayName("주문 완료 후 품절된 상품이 있으면 품절 이벤트를 발행한다.")
+    void handleOrderCompletedWithSoldOut() throws Exception {
+        // given
+        UUID orderId = UUID.randomUUID();
+        OrderCompletedEvent event = new OrderCompletedEvent(orderId, null, null, null, null, null,
+            null);
+        String message = objectMapper.writeValueAsString(event);
+        List<UUID> soldOutIds = List.of(UUID.randomUUID());
+
+        given(stockReservationService.commitStock(orderId)).willReturn(soldOutIds);
+
+        // when
+        stockEventHandler.handleOrderCompleted(message);
+
+        // then
+        verify(stockEventPublisher, times(1)).publishProductSoldOut(anyString());
+    }
+
+    @Test
+    @DisplayName("주문 완료 후 품절된 상품이 없으면 이벤트를 발행하지 않는다.")
+    void handleOrderCompletedNoSoldOut() throws Exception {
+        // given
+        UUID orderId = UUID.randomUUID();
+        OrderCompletedEvent event = new OrderCompletedEvent(orderId, null, null, null, null, null,
+            null);
+        String message = objectMapper.writeValueAsString(event);
+
+        given(stockReservationService.commitStock(orderId)).willReturn(List.of());
+
+        // when
+        stockEventHandler.handleOrderCompleted(message);
+
+        // then
+        verify(stockEventPublisher, never()).publishProductSoldOut(anyString());
+    }
+}

--- a/stock-service/src/test/java/com/destiny/stockservice/application/service/StockReservationServiceTest.java
+++ b/stock-service/src/test/java/com/destiny/stockservice/application/service/StockReservationServiceTest.java
@@ -1,0 +1,186 @@
+package com.destiny.stockservice.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.destiny.stockservice.application.dto.event.cancel.ConfirmedStockCancelEvent;
+import com.destiny.stockservice.application.dto.event.cancel.StockReservationCancelEvent;
+import com.destiny.stockservice.application.dto.event.reservation.StockReservationEvent;
+import com.destiny.stockservice.application.dto.event.reservation.StockReservationItem;
+import com.destiny.stockservice.domain.entity.ReservationStatus;
+import com.destiny.stockservice.domain.entity.Stock;
+import com.destiny.stockservice.domain.entity.StockReservation;
+import com.destiny.stockservice.domain.repository.StockRepository;
+import com.destiny.stockservice.domain.repository.StockReservationRepository;
+import com.destiny.stockservice.domain.result.ConfirmedStockCancelResult;
+import com.destiny.stockservice.domain.result.StockReservationCancelResult;
+import com.destiny.stockservice.domain.result.StockReservationResult;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class StockReservationServiceTest {
+
+    @InjectMocks
+    private StockReservationService stockReservationService;
+
+    @Mock
+    private StockRepository stockRepository;
+
+    @Mock
+    private StockReservationRepository stockReservationRepository;
+
+    @Test
+    @DisplayName("재고 예약 성공: 모든 상품의 재고가 충분할 때 RESERVED를 반환한다.")
+    void reserveStock_Success() {
+        // given
+        UUID productId = UUID.randomUUID();
+        UUID orderId = UUID.randomUUID();
+
+        Stock stock = new Stock(productId, 10);
+
+        StockReservationItem item = new StockReservationItem(productId, 3);
+        StockReservationEvent event = new StockReservationEvent(orderId, List.of(item));
+
+        given(stockRepository.findAllByProductIdIn(any())).willReturn(List.of(stock));
+
+        // when
+        StockReservationResult result = stockReservationService.reserveStock(event);
+
+        // then
+        assertThat(result).isEqualTo(StockReservationResult.RESERVED);
+        assertThat(stock.getReservedQuantity()).isEqualTo(3);
+        verify(stockReservationRepository, times(1))
+            .save(any(StockReservation.class));
+    }
+
+    @Test
+    @DisplayName("재고 예약 실패: 재고가 부족한 상품이 포함된 경우 OUT_OF_STOCK을 반환한다.")
+    void reserveStock_Fail_OutOfStock() {
+        // given
+        UUID productId = UUID.randomUUID();
+        Stock stock = new Stock(productId, 5);
+        StockReservationItem item = new StockReservationItem(productId, 10);
+        StockReservationEvent event = new StockReservationEvent(UUID.randomUUID(), List.of(item));
+
+        given(stockRepository.findAllByProductIdIn(any())).willReturn(List.of(stock));
+
+        // when
+        StockReservationResult result = stockReservationService.reserveStock(event);
+
+        // then
+        assertThat(result).isEqualTo(StockReservationResult.INVALID_REQUEST); // isInvalidStock 체크에서 걸림
+        verify(stockReservationRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("재고 확정(Commit): 예약된 재고를 차감하고 품절 여부를 반환한다.")
+    void commitStock_Success() {
+        // given
+        UUID orderId = UUID.randomUUID();
+        UUID productId = UUID.randomUUID();
+        Stock stock = new Stock(productId, 5);
+        stock.reserve(5); // reserved=5, available=0
+
+        StockReservation reservation = StockReservation.create(
+            productId,
+            orderId,
+            5
+        );
+
+        given(stockReservationRepository.findAllByOrderIdAndStatus(orderId, ReservationStatus.RESERVED))
+            .willReturn(List.of(reservation));
+        given(stockRepository.findAllByProductIdIn(any())).willReturn(List.of(stock));
+
+        // when
+        List<UUID> soldOutProductIds = stockReservationService.commitStock(orderId);
+
+        // then
+        assertThat(soldOutProductIds).containsExactly(productId);
+        assertThat(stock.getTotalQuantity()).isEqualTo(0);
+        assertThat(stock.getReservedQuantity()).isEqualTo(0);
+        assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.CONFIRMED);
+    }
+
+    @Test
+    @DisplayName("예약 취소: 예약된 수량을 다시 가용 재고로 복구한다.")
+    void cancelReservedStock_Success() {
+        // given
+        UUID sagaId = UUID.randomUUID();
+        UUID orderId = UUID.randomUUID();
+        UUID productId = UUID.randomUUID();
+        Stock stock = new Stock(productId, 10);
+        stock.reserve(3); // reserved=3
+
+        StockReservation reservation = StockReservation.create(productId, orderId, 3);
+
+        StockReservationCancelEvent.StockReservationCancelItem cancelItem =
+            new StockReservationCancelEvent.StockReservationCancelItem(productId, 3);
+
+        StockReservationCancelEvent event = new StockReservationCancelEvent(
+            sagaId,
+            orderId,
+            List.of(cancelItem)
+        );
+
+        given(stockReservationRepository.findAllByOrderIdAndStatus(orderId, ReservationStatus.RESERVED))
+            .willReturn(List.of(reservation));
+        given(stockRepository.findAllByProductIdIn(any())).willReturn(List.of(stock));
+
+        // when
+        StockReservationCancelResult result = stockReservationService.cancelReservedStock(event);
+
+        // then
+        assertThat(result).isEqualTo(StockReservationCancelResult.CANCEL_SUCCEEDED);
+        assertThat(stock.getReservedQuantity()).isEqualTo(0);
+        assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.CANCELED);
+    }
+
+    @Test
+    @DisplayName("확정된 재고 취소: 이미 차감된 전체 수량을 다시 복구한다.")
+    void cancelConfirmedStock_Success() {
+        // given
+        UUID sagaId = UUID.randomUUID();
+        UUID orderId = UUID.randomUUID();
+        UUID productId = UUID.randomUUID();
+        Stock stock = new Stock(productId, 5); // total=5
+
+        ConfirmedStockCancelEvent.StockCancelItem cancelItem =
+            new ConfirmedStockCancelEvent.StockCancelItem(
+                productId,
+                3
+            );
+
+        ConfirmedStockCancelEvent event = new ConfirmedStockCancelEvent(
+            sagaId,
+            orderId,
+            List.of(cancelItem)
+        );
+
+        StockReservation confirmedReservation = StockReservation.create(productId, orderId, 3);
+        // 수동으로 CONFIRMED 상태 설정 (도메인 로직에 따라)
+        confirmedReservation.confirm();
+
+        given(stockReservationRepository.findAllByOrderIdAndStatus(orderId, ReservationStatus.CONFIRMED))
+            .willReturn(List.of(confirmedReservation));
+        given(stockRepository.findAllByProductIdIn(any())).willReturn(List.of(stock));
+
+        // when
+        ConfirmedStockCancelResult result = stockReservationService.cancelConfirmedStock(event);
+
+        // then
+        assertThat(result).isEqualTo(ConfirmedStockCancelResult.CANCEL_SUCCEEDED);
+        assertThat(stock.getTotalQuantity()).isEqualTo(8); // 5 + 3
+        assertThat(confirmedReservation.getStatus()).isEqualTo(ReservationStatus.CANCELED);
+    }
+}

--- a/stock-service/src/test/java/com/destiny/stockservice/application/service/StockServiceTest.java
+++ b/stock-service/src/test/java/com/destiny/stockservice/application/service/StockServiceTest.java
@@ -1,0 +1,73 @@
+package com.destiny.stockservice.application.service;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.destiny.stockservice.application.dto.stock.StockCreateEvent;
+import com.destiny.stockservice.domain.entity.Stock;
+import com.destiny.stockservice.domain.repository.StockRepository;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class StockServiceTest {
+
+    @InjectMocks
+    private StockService stockService;
+
+    @Mock
+    private StockRepository stockRepository;
+
+    @Test
+    @DisplayName("새로운 상품의 재고를 생성한다.")
+    void createStock_Success() {
+        // given
+        UUID productId = UUID.randomUUID();
+        StockCreateEvent event = new StockCreateEvent(productId, 100);
+
+        given(stockRepository.findByProductId(productId)).willReturn(Optional.empty());
+
+        // when
+        stockService.createStock(event);
+
+        // then
+        verify(stockRepository, times(1)).save(any(Stock.class));
+    }
+
+    @Test
+    @DisplayName("이미 존재하는 상품의 재고를 생성시 예외가 발생한다.")
+    void createStock_Fail_AlreadyExists() {
+        // given
+        UUID productId = UUID.randomUUID();
+        StockCreateEvent event = new StockCreateEvent(productId, 100);
+        Stock existingStock = new Stock(productId, 50);
+
+        given(stockRepository.findByProductId(productId)).willReturn(Optional.of(existingStock));
+
+        // when & then
+        assertThrows(IllegalStateException.class, () -> {
+            stockService.createStock(event);
+        });
+
+        verify(stockRepository, never()).save(any(Stock.class));
+    }
+
+    @Test
+    @DisplayName("재고 생성시 이벤트 객체가 null이면 NPE가 발생한다.")
+    void createStock_Fail_NullEvent() {
+        // when & then
+        assertThrows(NullPointerException.class, () -> {
+            stockService.createStock(null);
+        });
+    }
+}

--- a/stock-service/src/test/java/com/destiny/stockservice/infrastructure/event/kafka/StockConsumerDltLoggingTest.java
+++ b/stock-service/src/test/java/com/destiny/stockservice/infrastructure/event/kafka/StockConsumerDltLoggingTest.java
@@ -1,0 +1,71 @@
+package com.destiny.stockservice.infrastructure.event.kafka;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.destiny.stockservice.application.StockEventHandler;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.Mockito;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+
+@ExtendWith(OutputCaptureExtension.class)
+class StockConsumerDltLoggingTest {
+
+    private static final String ANY_PAYLOAD = "{\"payload\":\"x\"}";
+
+    private static final String ANY_EXCEPTION_MESSAGE = "boom";
+
+    @ParameterizedTest
+    @DisplayName("StockDltHandler가 알고 있는 dlt 수신시 로그 출력 테스트")
+    @CsvSource({
+        "stock-reservation-request, 재고 예약 요청 처리 실패",
+        "stock-reservation-cancel, 재고 예약 취소 처리 실패",
+        "stock-cancel-request, 확정 재고 취소 요청 처리 실패",
+        "stock-create-message, 재고 생성 처리 실패",
+        "order-create-success, 주문 완료(재고 커밋) 이벤트 처리 실패"
+    })
+    void handleStockDlt_logsExpectedMessage_forKnownTopics(
+        String topic,
+        String expectedErrorMessage,
+        CapturedOutput output
+    ) {
+        StockConsumer consumer = newStockConsumer();
+
+        handleStockDlt(consumer, topic);
+
+        String combinedOutput = combinedOutput(output);
+        assertThat(combinedOutput)
+            .contains("DLT Topic")
+            .contains("원본 메시지")
+            .contains("예외 메시지")
+            .contains(expectedErrorMessage);
+    }
+
+    @Test
+    @DisplayName("StockDltHandler가 알 수 없는 dlt 토픽 수신시 로그 출력 테스트")
+    void handleStockDlt_logsUnknownMessage_forUnknownTopic(CapturedOutput output) {
+        StockConsumer consumer = newStockConsumer();
+
+        handleStockDlt(consumer, "unknown-topic-dlt");
+
+        assertThat(combinedOutput(output))
+            .contains("알 수 없는 Stock 관련 DLT 메시지");
+    }
+
+    private static StockConsumer newStockConsumer() {
+        StockEventHandler handler = Mockito.mock(StockEventHandler.class);
+        return new StockConsumer(handler);
+    }
+
+    private static void handleStockDlt(StockConsumer consumer, String topic) {
+        consumer.handleStockDlt(ANY_PAYLOAD, topic, ANY_EXCEPTION_MESSAGE);
+    }
+
+    private static String combinedOutput(CapturedOutput output) {
+        return output.getOut() + output.getErr();
+    }
+}

--- a/stock-service/src/test/java/com/destiny/stockservice/infrastructure/event/kafka/StockConsumerTest.java
+++ b/stock-service/src/test/java/com/destiny/stockservice/infrastructure/event/kafka/StockConsumerTest.java
@@ -1,0 +1,97 @@
+package com.destiny.stockservice.infrastructure.event.kafka;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import com.destiny.stockservice.application.StockEventHandler;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class StockConsumerTest {
+
+    @Mock
+    private StockEventHandler stockEventHandler;
+
+    @InjectMocks
+    private StockConsumer stockConsumer;
+
+    @Test
+    @DisplayName("재고 생성 메세지 수신시 재고 이벤트 핸들러로 전달")
+    void consumeStockCreate_callsHandler() {
+        String message = "{\"type\":\"stock-create\"}";
+
+        stockConsumer.consumeStockCreate(message);
+
+        verify(stockEventHandler).handleStockCreate(message);
+    }
+
+    @Test
+    @DisplayName("재고 생성 메세지 수신시 재고 이벤트 핸들러로 전달 테스트")
+    void consumeStockReservation_callsHandler() {
+        String message = "{\"type\":\"stock-reservation-request\"}";
+
+        stockConsumer.consumeStockReservation(message);
+
+        verify(stockEventHandler).handleStockReservation(message);
+    }
+
+    @Test
+    @DisplayName("재고 예약 메세지 수신시 재고 이벤트 핸들러로 전달 테스트")
+    void consumeStockReservationCancel_callsHandler() {
+        String message = "{\"type\":\"stock-reservation-cancel\"}";
+
+        stockConsumer.consumeStockReservationCancel(message);
+
+        verify(stockEventHandler).handleStockReservationCancel(message);
+    }
+
+    @Test
+    @DisplayName("확정 재고 취소 메세지 수신시 재고 이벤트 핸들러로 전달 테스트")
+    void consumeConfirmedStockCancel_callsHandler() {
+        String message = "{\"type\":\"stock-cancel-request\"}";
+
+        stockConsumer.consumeConfirmedStockCancel(message);
+
+        verify(stockEventHandler).handleConfirmedStockCancel(message);
+    }
+
+    @Test
+    @DisplayName("주문 완료 메세지 수신시 재고 이벤트 핸들러로 전달 테스트")
+    void consumeOrderCompleted_callsHandler() {
+        String message = "{\"type\":\"order-create-success\"}";
+
+        stockConsumer.consumeOrderCompleted(message);
+
+        verify(stockEventHandler).handleOrderCompleted(message);
+    }
+
+    @Test
+    @DisplayName("Stock DLT 처리: 알려진 토픽이면 예외 없이 로깅한다")
+    void handleStockDlt_doesNotThrow_forKnownTopic() {
+        assertDoesNotThrow(() -> stockConsumer.handleStockDlt(
+            "{\"payload\":\"x\"}",
+            "stock-reservation-request-dlt",
+            "some exception"
+        ));
+
+        verifyNoInteractions(stockEventHandler);
+    }
+
+    @Test
+    @DisplayName("Stock DLT 처리: 알 수 없는 토픽이어도 예외 없이 로깅한다")
+    void handleStockDlt_doesNotThrow_forUnknownTopic() {
+        assertDoesNotThrow(() -> stockConsumer.handleStockDlt(
+            "{\"payload\":\"x\"}",
+            "some-unknown-topic-dlt",
+            "some exception"
+        ));
+
+        verifyNoInteractions(stockEventHandler);
+    }
+}

--- a/stock-service/src/test/java/com/destiny/stockservice/infrastructure/event/kafka/StockProducerTest.java
+++ b/stock-service/src/test/java/com/destiny/stockservice/infrastructure/event/kafka/StockProducerTest.java
@@ -1,0 +1,101 @@
+package com.destiny.stockservice.infrastructure.event.kafka;
+
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.core.KafkaTemplate;
+
+@ExtendWith(MockitoExtension.class)
+class StockProducerTest {
+
+    @Mock
+    private KafkaTemplate<String, String> kafkaTemplate;
+
+    @InjectMocks
+    private StockProducer stockProducer;
+
+    @Test
+    @DisplayName("[재고 예약 성공 이벤트 발행] topic : stock-reservation-success")
+    void publishReservationSuccess_sendsToCorrectTopic() {
+        String event = "{\"type\":\"stock-reservation-success\"}";
+
+        stockProducer.publishReservationSuccess(event);
+
+        verify(kafkaTemplate).send("stock-reservation-success", event);
+    }
+
+    @Test
+    @DisplayName("[재고 예약 실패 이벤트 발행] topic : stock-reservation-fail")
+    void publishReservationFail_sendsToCorrectTopic() {
+        String event = "{\"type\":\"stock-reservation-fail\"}";
+
+        stockProducer.publishReservationFail(event);
+
+        verify(kafkaTemplate).send("stock-reservation-fail", event);
+    }
+
+    @Test
+    @DisplayName("[재고 예약 취소 성공 이벤트 발행] topic : stock-reservation-cancel-success")
+    void publishReservationCancelSuccess_sendsToCorrectTopic() {
+        String event = "{\"type\":\"stock-reservation-cancel-success\"}";
+
+        stockProducer.publishReservationCancelSuccess(event);
+
+        verify(kafkaTemplate).send("stock-reservation-cancel-success", event);
+    }
+
+    @Test
+    @DisplayName("[재고 예약 취소 실패 이벤트 발행] topic : stock-reservation-cancel-fail")
+    void publishReservationCancelFail_sendsToCorrectTopic() {
+        String event = "{\"type\":\"stock-reservation-cancel-fail\"}";
+
+        stockProducer.publishReservationCancelFail(event);
+
+        verify(kafkaTemplate).send("stock-reservation-cancel-fail", event);
+    }
+
+    @Test
+    @DisplayName("[확정 재고 취소 성공 이벤트 발행] topic : stock-cancel-success")
+    void publishConfirmedStockCancelSuccess_sendsToCorrectTopic() {
+        String event = "{\"type\":\"stock-cancel-success\"}";
+
+        stockProducer.publishConfirmedStockCancelSuccess(event);
+
+        verify(kafkaTemplate).send("stock-cancel-success", event);
+    }
+
+    @Test
+    @DisplayName("[확정 재고 취소 실패 이벤트 발행] topic : stock-cancel-fail")
+    void publishConfirmedStockCancelFail_sendsToCorrectTopic() {
+        String event = "{\"type\":\"stock-cancel-fail\"}";
+
+        stockProducer.publishConfirmedStockCancelFail(event);
+
+        verify(kafkaTemplate).send("stock-cancel-fail", event);
+    }
+
+    @Test
+    @DisplayName("[상품 품절 이벤트 발행] topic : product-close-event")
+    void publishProductSoldOut_sendsToCorrectTopic() {
+        String event = "{\"type\":\"product-close-event\"}";
+
+        stockProducer.publishProductSoldOut(event);
+
+        verify(kafkaTemplate).send("product-close-event", event);
+    }
+
+    @Test
+    @DisplayName("[상품 재판매 이벤트 발행] topic : product-reopen-event")
+    void publishProductReopen_sendsToCorrectTopic() {
+        String event = "{\"type\":\"product-reopen-event\"}";
+
+        stockProducer.publishProductReopen(event);
+
+        verify(kafkaTemplate).send("product-reopen-event", event);
+    }
+}

--- a/stock-service/src/test/java/com/destiny/stockservice/service/StockReservationServiceTest.java
+++ b/stock-service/src/test/java/com/destiny/stockservice/service/StockReservationServiceTest.java
@@ -1,0 +1,188 @@
+package com.destiny.stockservice.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.destiny.stockservice.application.dto.event.cancel.ConfirmedStockCancelEvent;
+import com.destiny.stockservice.application.dto.event.cancel.StockReservationCancelEvent;
+import com.destiny.stockservice.application.dto.event.reservation.StockReservationEvent;
+import com.destiny.stockservice.application.dto.event.reservation.StockReservationItem;
+import com.destiny.stockservice.application.service.StockReservationService;
+import com.destiny.stockservice.domain.entity.ReservationStatus;
+import com.destiny.stockservice.domain.entity.Stock;
+import com.destiny.stockservice.domain.entity.StockReservation;
+import com.destiny.stockservice.domain.repository.StockRepository;
+import com.destiny.stockservice.domain.repository.StockReservationRepository;
+import com.destiny.stockservice.domain.result.ConfirmedStockCancelResult;
+import com.destiny.stockservice.domain.result.StockReservationCancelResult;
+import com.destiny.stockservice.domain.result.StockReservationResult;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class StockReservationServiceTest {
+
+    @InjectMocks
+    private StockReservationService stockReservationService;
+
+    @Mock
+    private StockRepository stockRepository;
+
+    @Mock
+    private StockReservationRepository stockReservationRepository;
+
+    @Test
+    @DisplayName("재고 예약 성공: 모든 상품의 재고가 충분할 때 RESERVED를 반환한다.")
+    void reserveStock_Success() {
+        // given
+        UUID productId = UUID.randomUUID();
+        UUID orderId = UUID.randomUUID();
+
+        Stock stock = new Stock(productId, 10);
+
+        StockReservationItem item = new StockReservationItem(productId, 3);
+        StockReservationEvent event = new StockReservationEvent(orderId, List.of(item));
+
+        given(stockRepository.findAllByProductIdIn(any())).willReturn(List.of(stock));
+
+        // when
+        StockReservationResult result = stockReservationService.reserveStock(event);
+
+        // then
+        assertThat(result).isEqualTo(StockReservationResult.RESERVED);
+        assertThat(stock.getReservedQuantity()).isEqualTo(3);
+        verify(stockReservationRepository, times(1))
+            .save(any(StockReservation.class));
+    }
+
+    @Test
+    @DisplayName("재고 예약 실패: 재고가 부족한 상품이 포함된 경우 OUT_OF_STOCK을 반환한다.")
+    void reserveStock_Fail_OutOfStock() {
+        // given
+        UUID productId = UUID.randomUUID();
+        Stock stock = new Stock(productId, 5);
+        StockReservationItem item = new StockReservationItem(productId, 10);
+        StockReservationEvent event = new StockReservationEvent(UUID.randomUUID(), List.of(item));
+
+        given(stockRepository.findAllByProductIdIn(any())).willReturn(List.of(stock));
+
+        // when
+        StockReservationResult result = stockReservationService.reserveStock(event);
+
+        // then
+        assertThat(result).isEqualTo(StockReservationResult.INVALID_REQUEST); // isInvalidStock 체크에서 걸림
+        verify(stockReservationRepository, never()).save(any());
+    }
+
+
+    @Test
+    @DisplayName("재고 확정(Commit): 예약된 재고를 차감하고 품절 여부를 반환한다.")
+    void commitStock_Success() {
+        // given
+        UUID orderId = UUID.randomUUID();
+        UUID productId = UUID.randomUUID();
+        Stock stock = new Stock(productId, 5);
+        stock.reserve(5); // reserved=5, available=0
+
+        StockReservation reservation = StockReservation.create(
+            productId,
+            orderId,
+            5
+        );
+
+        given(stockReservationRepository.findAllByOrderIdAndStatus(orderId, ReservationStatus.RESERVED))
+            .willReturn(List.of(reservation));
+        given(stockRepository.findAllByProductIdIn(any())).willReturn(List.of(stock));
+
+        // when
+        List<UUID> soldOutProductIds = stockReservationService.commitStock(orderId);
+
+        // then
+        assertThat(soldOutProductIds).containsExactly(productId);
+        assertThat(stock.getTotalQuantity()).isEqualTo(0);
+        assertThat(stock.getReservedQuantity()).isEqualTo(0);
+        assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.CONFIRMED);
+    }
+
+    @Test
+    @DisplayName("예약 취소: 예약된 수량을 다시 가용 재고로 복구한다.")
+    void cancelReservedStock_Success() {
+        // given
+        UUID sagaId = UUID.randomUUID();
+        UUID orderId = UUID.randomUUID();
+        UUID productId = UUID.randomUUID();
+        Stock stock = new Stock(productId, 10);
+        stock.reserve(3); // reserved=3
+
+        StockReservation reservation = StockReservation.create(productId, orderId, 3);
+
+        StockReservationCancelEvent.StockReservationCancelItem cancelItem =
+            new StockReservationCancelEvent.StockReservationCancelItem(productId, 3);
+
+        StockReservationCancelEvent event = new StockReservationCancelEvent(
+            sagaId,
+            orderId,
+            List.of(cancelItem)
+        );
+
+        given(stockReservationRepository.findAllByOrderIdAndStatus(orderId, ReservationStatus.RESERVED))
+            .willReturn(List.of(reservation));
+        given(stockRepository.findAllByProductIdIn(any())).willReturn(List.of(stock));
+
+        // when
+        StockReservationCancelResult result = stockReservationService.cancelReservedStock(event);
+
+        // then
+        assertThat(result).isEqualTo(StockReservationCancelResult.CANCEL_SUCCEEDED);
+        assertThat(stock.getReservedQuantity()).isEqualTo(0);
+        assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.CANCELED);
+    }
+
+    @Test
+    @DisplayName("확정된 재고 취소: 이미 차감된 전체 수량을 다시 복구한다.")
+    void cancelConfirmedStock_Success() {
+        // given
+        UUID sagaId = UUID.randomUUID();
+        UUID orderId = UUID.randomUUID();
+        UUID productId = UUID.randomUUID();
+        Stock stock = new Stock(productId, 5); // total=5
+
+        ConfirmedStockCancelEvent.StockCancelItem cancelItem =
+            new ConfirmedStockCancelEvent.StockCancelItem(
+                productId,
+                3
+            );
+
+        ConfirmedStockCancelEvent event = new ConfirmedStockCancelEvent(
+            sagaId,
+            orderId,
+            List.of(cancelItem)
+        );
+
+        StockReservation confirmedReservation = StockReservation.create(productId, orderId, 3);
+        // 수동으로 CONFIRMED 상태 설정 (도메인 로직에 따라)
+        confirmedReservation.confirm();
+
+        given(stockReservationRepository.findAllByOrderIdAndStatus(orderId, ReservationStatus.CONFIRMED))
+            .willReturn(List.of(confirmedReservation));
+        given(stockRepository.findAllByProductIdIn(any())).willReturn(List.of(stock));
+
+        // when
+        ConfirmedStockCancelResult result = stockReservationService.cancelConfirmedStock(event);
+
+        // then
+        assertThat(result).isEqualTo(ConfirmedStockCancelResult.CANCEL_SUCCEEDED);
+        assertThat(stock.getTotalQuantity()).isEqualTo(8); // 5 + 3
+        assertThat(confirmedReservation.getStatus()).isEqualTo(ReservationStatus.CANCELED);
+    }
+}

--- a/stock-service/src/test/java/com/destiny/stockservice/service/StockServiceTest.java
+++ b/stock-service/src/test/java/com/destiny/stockservice/service/StockServiceTest.java
@@ -1,0 +1,74 @@
+package com.destiny.stockservice.service;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.destiny.stockservice.application.dto.stock.StockCreateEvent;
+import com.destiny.stockservice.application.service.StockService;
+import com.destiny.stockservice.domain.entity.Stock;
+import com.destiny.stockservice.domain.repository.StockRepository;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class StockServiceTest {
+
+    @InjectMocks
+    private StockService stockService;
+
+    @Mock
+    private StockRepository stockRepository;
+
+    @Test
+    @DisplayName("새로운 상품의 재고를 생성한다.")
+    void createStock_Success() {
+        // given
+        UUID productId = UUID.randomUUID();
+        StockCreateEvent event = new StockCreateEvent(productId, 100);
+
+        given(stockRepository.findByProductId(productId)).willReturn(Optional.empty());
+
+        // when
+        stockService.createStock(event);
+
+        // then
+        verify(stockRepository, times(1)).save(any(Stock.class));
+    }
+
+    @Test
+    @DisplayName("이미 존재하는 상품의 재고를 생성시 예외가 발생한다.")
+    void createStock_Fail_AlreadyExists() {
+        // given
+        UUID productId = UUID.randomUUID();
+        StockCreateEvent event = new StockCreateEvent(productId, 100);
+        Stock existingStock = new Stock(productId, 50);
+
+        given(stockRepository.findByProductId(productId)).willReturn(Optional.of(existingStock));
+
+        // when & then
+        assertThrows(IllegalStateException.class, () -> {
+            stockService.createStock(event);
+        });
+
+        verify(stockRepository, never()).save(any(Stock.class));
+    }
+
+    @Test
+    @DisplayName("재고 생성시 이벤트 객체가 null이면 NPE가 발생한다.")
+    void createStock_Fail_NullEvent() {
+        // when & then
+        assertThrows(NullPointerException.class, () -> {
+            stockService.createStock(null);
+        });
+    }
+}


### PR DESCRIPTION
## 📝 재고 서비스
단위 테스트 추가
- StockEventHandlerTest
- StockReservationServiceTest
- StockServiceTest
- StockConsumerDltLoggingTest
- StockConsumerTest
- StockProducerTest
---

### ✨ 작업 내용 요약

- [x] 단위 테스트 작성


### 📸 스크린샷
<img width="692" height="200" alt="스크린샷 2025-12-26 오후 3 54 15" src="https://github.com/user-attachments/assets/457165cc-3aa8-42aa-93fb-ed7a7fb03a51" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
* 주식 서비스의 포괄적인 단위 테스트 스위트 추가
  * 주식 생성, 예약, 취소 및 주문 완료 기능에 대한 테스트 추가
  * 성공 및 실패 시나리오에 대한 검증 강화
  * Kafka 메시지 소비 및 발행 메커니즘 검증
  * 오류 처리 및 Dead Letter Topic 로깅 시나리오 테스트

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->